### PR TITLE
Fix start+rotation_virtual_start bug

### DIFF
--- a/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/pagerduty/data_source_pagerduty_schedule_test.go
@@ -14,8 +14,8 @@ func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
-	start := "2020-05-24T20:00:00-04:00"
-	rotationVirtualStart := "2020-05-24T20:00:00-04:00"
+	start := "2020-05-25T02:00:00+02:00"
+	rotationVirtualStart := "2020-05-25T02:00:00+02:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/pagerduty/data_source_pagerduty_schedule_test.go
@@ -13,13 +13,16 @@ func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "Europe/Berlin"
+	start := "2020-05-24T20:00:00-04:00"
+	rotationVirtualStart := "2020-05-24T20:00:00-04:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePagerDutyScheduleConfig(username, email, schedule),
+				Config: testAccDataSourcePagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutySchedule("pagerduty_schedule.test", "data.pagerduty_schedule.by_name"),
 				),
@@ -53,7 +56,7 @@ func testAccDataSourcePagerDutySchedule(src, n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyScheduleConfig(username, email, schedule string) string {
+func testAccDataSourcePagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
   name  = "%s"
@@ -63,12 +66,12 @@ resource "pagerduty_user" "test" {
 resource "pagerduty_schedule" "test" {
   name = "%s"
 
-  time_zone = "America/New_York"
+  time_zone = "%s"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.test.id}"]
 
@@ -84,5 +87,5 @@ resource "pagerduty_schedule" "test" {
 data "pagerduty_schedule" "by_name" {
   name = "${pagerduty_schedule.test.name}"
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }

--- a/pagerduty/errors.go
+++ b/pagerduty/errors.go
@@ -1,1 +1,0 @@
-package pagerduty

--- a/pagerduty/import_pagerduty_schedule_test.go
+++ b/pagerduty/import_pagerduty_schedule_test.go
@@ -12,6 +12,9 @@ func TestAccPagerDutySchedule_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "Europe/Berlin"
+	start := "2020-05-12T20:00:00+02:00"
+	rotationVirtualStart := "2020-05-12T20:00:00+02:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +22,7 @@ func TestAccPagerDutySchedule_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
+				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart),
 			},
 
 			{

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -47,14 +47,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 						},
 						"start": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if old == "" {
-									return false
-								}
-								return true
-							},
+							Required: true,
 						},
 						"end": {
 							Type:     schema.TypeString,
@@ -62,14 +55,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 						},
 						"rotation_virtual_start": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if old == "" {
-									return false
-								}
-								return true
-							},
+							Required: true,
 						},
 						"rotation_turn_length_seconds": {
 							Type:     schema.TypeInt,

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -45,6 +45,9 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "America/New_York"
+	start := "2020-05-12T20:00:00-04:00"
+	rotationVirtualStart := "2020-05-12T20:00:00-04:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +55,7 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
+				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -60,15 +63,19 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "time_zone", "Europe/Berlin"),
+						"pagerduty_schedule.foo", "time_zone", location),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyScheduleConfigUpdated(username, email, scheduleUpdated),
+				Config: testAccCheckPagerDutyScheduleConfigUpdated(username, email, scheduleUpdated, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -76,11 +83,15 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "time_zone", "America/New_York"),
+						"pagerduty_schedule.foo", "time_zone", location),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 		},
@@ -92,6 +103,9 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "Australia/Melbourne"
+	start := "2020-05-12T20:00:00+10:00"
+	rotationVirtualStart := "2020-05-12T20:00:00+10:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -99,7 +113,7 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule),
+				Config: testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -107,17 +121,21 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "time_zone", "Europe/Berlin"),
+						"pagerduty_schedule.foo", "time_zone", location),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.restriction.0.start_day_of_week", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, scheduleUpdated),
+				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, scheduleUpdated, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -125,13 +143,17 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "time_zone", "America/New_York"),
+						"pagerduty_schedule.foo", "time_zone", location),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.restriction.0.start_day_of_week", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 		},
@@ -142,6 +164,9 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "Europe/Berlin"
+	start := "2020-05-12T20:00:00+02:00"
+	rotationVirtualStart := "2020-05-12T20:00:00+02:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -149,7 +174,7 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule),
+				Config: testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule, location, start, rotationVirtualStart),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -157,7 +182,7 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "time_zone", "America/New_York"),
+						"pagerduty_schedule.foo", "time_zone", location),
 
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "3"),
@@ -171,11 +196,12 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.0.restriction.0.start_time_of_day", "08:00:00"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.rotation_turn_length_seconds", "86400"),
-					// NOTE: Temporarily disabled due to API inconsistencies
-					// resource.TestCheckResourceAttr(
-					// "pagerduty_schedule.foo", "layer.0.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.users.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.1.name", "bar"),
@@ -189,11 +215,12 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.1.restriction.0.start_day_of_week", "5"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.1.rotation_turn_length_seconds", "86400"),
-					// NOTE: Temporarily disabled due to API inconsistencies
-					// resource.TestCheckResourceAttr(
-					// "pagerduty_schedule.foo", "layer.1.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.1.users.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.rotation_virtual_start", rotationVirtualStart),
 
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.2.name", "foobar"),
@@ -207,11 +234,12 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.2.restriction.0.start_day_of_week", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.2.rotation_turn_length_seconds", "86400"),
-					// NOTE: Temporarily disabled due to API inconsistencies
-					// resource.TestCheckResourceAttr(
-					// "pagerduty_schedule.foo", "layer.2.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.2.users.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 		},
@@ -258,7 +286,7 @@ func testAccCheckPagerDutyScheduleExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckPagerDutyScheduleConfig(username, email, schedule string) string {
+func testAccCheckPagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name  = "%s"
@@ -268,13 +296,13 @@ resource "pagerduty_user" "foo" {
 resource "pagerduty_schedule" "foo" {
   name = "%s"
 
-  time_zone   = "Europe/Berlin"
+  time_zone   = "%s"
   description = "foo"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -285,10 +313,10 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }
 
-func testAccCheckPagerDutyScheduleConfigUpdated(username, email, schedule string) string {
+func testAccCheckPagerDutyScheduleConfigUpdated(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%s"
@@ -298,12 +326,12 @@ resource "pagerduty_user" "foo" {
 resource "pagerduty_schedule" "foo" {
   name = "%s"
 
-  time_zone = "America/New_York"
+  time_zone = "%s"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -314,10 +342,10 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }
 
-func testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule string) string {
+func testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name  = "%s"
@@ -327,13 +355,13 @@ resource "pagerduty_user" "foo" {
 resource "pagerduty_schedule" "foo" {
   name = "%s"
 
-  time_zone   = "Europe/Berlin"
+  time_zone   = "%s"
   description = "foo"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -345,10 +373,10 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }
 
-func testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, schedule string) string {
+func testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%s"
@@ -358,12 +386,12 @@ resource "pagerduty_user" "foo" {
 resource "pagerduty_schedule" "foo" {
   name = "%s"
 
-  time_zone = "America/New_York"
+  time_zone = "%s"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -375,10 +403,10 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }
 
-func testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule string) string {
+func testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%s"
@@ -388,13 +416,13 @@ resource "pagerduty_user" "foo" {
 resource "pagerduty_schedule" "foo" {
   name = "%s"
 
-  time_zone   = "America/New_York"
+  time_zone   = "%s"
   description = "foo"
 
   layer {
     name                         = "foo"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%[5]v"
+    rotation_virtual_start       = "%[6]v"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -407,8 +435,8 @@ resource "pagerduty_schedule" "foo" {
 
   layer {
     name                         = "bar"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%[5]v"
+    rotation_virtual_start       = "%[6]v"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -422,8 +450,8 @@ resource "pagerduty_schedule" "foo" {
 
   layer {
     name                         = "foobar"
-    start                        = "2015-11-06T20:00:00-05:00"
-    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    start                        = "%[5]v"
+    rotation_virtual_start       = "%[6]v"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 
@@ -435,5 +463,5 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`, username, email, schedule)
+`, username, email, schedule, location, start, rotationVirtualStart)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/addon.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/addon.go
@@ -20,7 +20,10 @@ type Addon struct {
 
 // ListAddonsOptions represents options when listing add-ons.
 type ListAddonsOptions struct {
-	*Pagination
+	Limit      int      `url:"limit,omitempty"`
+	More       bool     `url:"more,omitempty"`
+	Offset     int      `url:"offset,omitempty"`
+	Total      int      `url:"total,omitempty"`
 	Filter     string   `url:"filter,omitempty"`
 	Include    []string `url:"include,omitempty,brackets"`
 	ServiceIDs []string `url:"service_ids,omitempty,brackets"`
@@ -28,7 +31,10 @@ type ListAddonsOptions struct {
 
 // ListAddonsResponse represents a list response of add-ons.
 type ListAddonsResponse struct {
-	Pagination
+	Limit  int      `url:"limit,omitempty"`
+	More   bool     `url:"more,omitempty"`
+	Offset int      `url:"offset,omitempty"`
+	Total  int      `url:"total,omitempty"`
 	Addons []*Addon `json:"addons,omitempty"`
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
@@ -32,19 +32,28 @@ type EscalationPolicy struct {
 
 // ListEscalationPoliciesResponse represents a list response of escalation policies.
 type ListEscalationPoliciesResponse struct {
-	*Pagination
+	Limit              int                 `url:"limit,omitempty"`
+	More               bool                `url:"more,omitempty"`
+	Offset             int                 `url:"offset,omitempty"`
+	Total              int                 `url:"total,omitempty"`
 	EscalationPolicies []*EscalationPolicy `json:"escalation_policies,omitempty"`
 }
 
 // ListEscalationRulesResponse represents a list response of escalation rules.
 type ListEscalationRulesResponse struct {
-	*Pagination
+	Limit           int               `url:"limit,omitempty"`
+	More            bool              `url:"more,omitempty"`
+	Offset          int               `url:"offset,omitempty"`
+	Total           int               `url:"total,omitempty"`
 	EscalationRules []*EscalationRule `json:"escalation_rules,omitempty"`
 }
 
 // ListEscalationPoliciesOptions represents options when listing escalation policies.
 type ListEscalationPoliciesOptions struct {
-	Pagination
+	Limit    int      `url:"limit,omitempty"`
+	More     bool     `url:"more,omitempty"`
+	Offset   int      `url:"offset,omitempty"`
+	Total    int      `url:"total,omitempty"`
 	Includes []string `url:"include,omitempty,brackets"`
 	Query    string   `url:"query,omitempty"`
 	SortBy   string   `url:"sort_by,omitempty"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -49,14 +49,6 @@ type Response struct {
 	*http.Response
 }
 
-// Pagination contains pagination information
-type Pagination struct {
-	Limit  int  `url:"limit,omitempty"`
-	More   bool `url:"more,omitempty"`
-	Offset int  `url:"offset,omitempty"`
-	Total  int  `url:"total,omitempty"`
-}
-
 // NewClient returns a new PagerDuty API client.
 func NewClient(config *Config) (*Client, error) {
 	if config.HTTPClient == nil {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
@@ -1,6 +1,9 @@
 package pagerduty
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // ScheduleService handles the communication with schedule
 // related methods of the PagerDuty API.
@@ -62,13 +65,19 @@ type ScheduleLayer struct {
 
 // ListSchedulesOptions represents options when listing schedules.
 type ListSchedulesOptions struct {
-	*Pagination
-	Query string `url:"query,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	More   bool   `url:"more,omitempty"`
+	Offset int    `url:"offset,omitempty"`
+	Total  int    `url:"total,omitempty"`
+	Query  string `url:"query,omitempty"`
 }
 
 // ListSchedulesResponse represents a list response of schedules.
 type ListSchedulesResponse struct {
-	*Pagination
+	Limit     int         `url:"limit,omitempty"`
+	More      bool        `url:"more,omitempty"`
+	Offset    int         `url:"offset,omitempty"`
+	Total     int         `url:"total,omitempty"`
 	Schedules []*Schedule `json:"schedules,omitempty"`
 }
 
@@ -102,6 +111,12 @@ func (s *ScheduleService) Create(schedule *Schedule) (*Schedule, *Response, erro
 	u := "/schedules"
 	v := new(Schedule)
 
+	for _, layer := range schedule.ScheduleLayers {
+		if err := normalizeTime(layer); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	resp, err := s.client.newRequestDo("POST", u, nil, &Schedule{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
@@ -134,10 +149,49 @@ func (s *ScheduleService) Update(id string, schedule *Schedule) (*Schedule, *Res
 	u := fmt.Sprintf("/schedules/%s", id)
 	v := new(Schedule)
 
+	for _, layer := range schedule.ScheduleLayers {
+		if err := normalizeTime(layer); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	resp, err := s.client.newRequestDo("PUT", u, nil, &Schedule{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return v.Schedule, resp, nil
+}
+
+func normalizeTime(l *ScheduleLayer) error {
+	s, err := timeToUTC(l.Start)
+	if err != nil {
+		return err
+	}
+	l.Start = s
+
+	rvs, err := timeToUTC(l.RotationVirtualStart)
+	if err != nil {
+		return err
+	}
+	l.RotationVirtualStart = rvs
+
+	if l.End != "" {
+		e, err := timeToUTC(l.End)
+		if err != nil {
+			return err
+		}
+		l.End = e
+	}
+
+	return nil
+}
+
+func timeToUTC(v string) (string, error) {
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return "", err
+	}
+
+	return t.UTC().String(), nil
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -90,7 +90,10 @@ type GetIntegrationOptions struct {
 
 // ListServicesOptions represents options when listing services.
 type ListServicesOptions struct {
-	*Pagination
+	Limit    int      `url:"limit,omitempty"`
+	More     bool     `url:"more,omitempty"`
+	Offset   int      `url:"offset,omitempty"`
+	Total    int      `url:"total,omitempty"`
 	Includes []string `url:"include,omitempty,brackets"`
 	Query    string   `url:"query,omitempty"`
 	SortBy   string   `url:"sort_by,omitempty"`
@@ -100,7 +103,10 @@ type ListServicesOptions struct {
 
 // ListServicesResponse represents a list response of services.
 type ListServicesResponse struct {
-	*Pagination
+	Limit    int  `url:"limit,omitempty"`
+	More     bool `url:"more,omitempty"`
+	Offset   int  `url:"offset,omitempty"`
+	Total    int  `url:"total,omitempty"`
 	Services []*Service
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
@@ -20,14 +20,20 @@ type Team struct {
 
 // ListTeamsOptions represents options when listing teams.
 type ListTeamsOptions struct {
-	*Pagination
-	Query string `url:"query,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	More   bool   `url:"more,omitempty"`
+	Offset int    `url:"offset,omitempty"`
+	Total  int    `url:"total,omitempty"`
+	Query  string `url:"query,omitempty"`
 }
 
 // ListTeamsResponse represents a list response of teams.
 type ListTeamsResponse struct {
-	*Pagination
-	Teams []*Team `json:"teams,omitempty"`
+	Limit  int     `url:"limit,omitempty"`
+	More   bool    `url:"more,omitempty"`
+	Offset int     `url:"offset,omitempty"`
+	Total  int     `url:"total,omitempty"`
+	Teams  []*Team `json:"teams,omitempty"`
 }
 
 // List lists existing teams.

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
@@ -42,7 +42,10 @@ type User struct {
 
 // ListUsersOptions represents options when listing users.
 type ListUsersOptions struct {
-	*Pagination
+	Limit   int      `url:"limit,omitempty"`
+	More    bool     `url:"more,omitempty"`
+	Offset  int      `url:"offset,omitempty"`
+	Total   int      `url:"total,omitempty"`
 	Include []string `url:"include,omitempty,brackets"`
 	Query   string   `url:"query,omitempty"`
 	TeamIDs []string `url:"team_ids,omitempty,brackets"`
@@ -50,8 +53,11 @@ type ListUsersOptions struct {
 
 // ListUsersResponse represents a list response of users.
 type ListUsersResponse struct {
-	*Pagination
-	Users []*User `json:"users,omitempty"`
+	Limit  int     `url:"limit,omitempty"`
+	More   bool    `url:"more,omitempty"`
+	Offset int     `url:"offset,omitempty"`
+	Total  int     `url:"total,omitempty"`
+	Users  []*User `json:"users,omitempty"`
 }
 
 // GetUserOptions represents options when retrieving a user.

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/vendor.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/vendor.go
@@ -27,13 +27,19 @@ type Vendor struct {
 
 // ListVendorsOptions represents options when listing vendors.
 type ListVendorsOptions struct {
-	*Pagination
-	Query string `url:"query,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	More   bool   `url:"more,omitempty"`
+	Offset int    `url:"offset,omitempty"`
+	Total  int    `url:"total,omitempty"`
+	Query  string `url:"query,omitempty"`
 }
 
 // ListVendorsResponse represents a list response of vendors.
 type ListVendorsResponse struct {
-	*Pagination
+	Limit   int       `url:"limit,omitempty"`
+	More    bool      `url:"more,omitempty"`
+	Offset  int       `url:"offset,omitempty"`
+	Total   int       `url:"total,omitempty"`
 	Vendors []*Vendor `json:"vendors,omitempty"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -496,10 +496,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "Zoo7/Qb2MiAicSMYdrBwB0uhu70=",
+			"checksumSHA1": "ERg1YD7bZcvqsMHOrUpO7MfJXVA=",
 			"path": "github.com/heimweh/go-pagerduty/pagerduty",
-			"revision": "5c1b519e2baf3f98c7eb3799e28781de10f0bdcc",
-			"revisionTime": "2017-06-27T14:55:55Z"
+			"revision": "88fb561f357fa105b3928cef961ae75820af42af",
+			"revisionTime": "2017-06-29T11:31:45Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",


### PR DESCRIPTION
This PR aims to resolve the issue reported in https://github.com/hashicorp/terraform/issues/11424. 

Due to some inconsistencies in the PagerDuty API it's been difficult to set these fields in the past without getting a constant diff in Terraform but after some help from the PagerDuty support we came to the conclusion that it should work correctly if sending the `start` & `rotation_virtual_start` fields as UTC.
