### PR TITLE
Add sweeper

### DIFF
--- a/pagerduty/resource_pagerduty_addon_test.go
+++ b/pagerduty/resource_pagerduty_addon_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepAddon(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepAddon(region string) error {
 
 	for _, addon := range resp.Addons {
 		if strings.HasPrefix(addon.Name, "test") || strings.HasPrefix(addon.Name, "tf-") {
+			log.Printf("Destroying add-on %s (%s)", addon.Name, addon.ID)
 			if _, err := client.Addons.Delete(addon.ID); err != nil {
 				return err
 			}

--- a/pagerduty/resource_pagerduty_addon_test.go
+++ b/pagerduty/resource_pagerduty_addon_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepAddon(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Addons.List(&pagerduty.ListAddonsOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, addon := range resp.Addons {
+		if strings.HasPrefix(addon.Name, "test") || strings.HasPrefix(addon.Name, "tf-") {
+			if _, err := client.Addons.Delete(addon.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutyAddon_Basic(t *testing.T) {
 	addon := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepEscalationPolicy(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.EscalationPolicies.List(&pagerduty.ListEscalationPoliciesOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, escalation := range resp.EscalationPolicies {
+		if strings.HasPrefix(escalation.Name, "test") || strings.HasPrefix(escalation.Name, "tf-") {
+			if _, err := client.EscalationPolicies.Delete(escalation.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepEscalationPolicy(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepEscalationPolicy(region string) error {
 
 	for _, escalation := range resp.EscalationPolicies {
 		if strings.HasPrefix(escalation.Name, "test") || strings.HasPrefix(escalation.Name, "tf-") {
+			log.Printf("Destroying escalation policy %s (%s)", escalation.Name, escalation.ID)
 			if _, err := client.EscalationPolicies.Delete(escalation.ID); err != nil {
 				return err
 			}

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepSchedule(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepSchedule(region string) error {
 
 	for _, schedule := range resp.Schedules {
 		if strings.HasPrefix(schedule.Name, "test") || strings.HasPrefix(schedule.Name, "tf-") {
+			log.Printf("Destroying schedule %s (%s)", schedule.Name, schedule.ID)
 			if _, err := client.Schedules.Delete(schedule.ID); err != nil {
 				return err
 			}

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepSchedule(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Schedules.List(&pagerduty.ListSchedulesOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, schedule := range resp.Schedules {
+		if strings.HasPrefix(schedule.Name, "test") || strings.HasPrefix(schedule.Name, "tf-") {
+			if _, err := client.Schedules.Delete(schedule.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutySchedule_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepService(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepService(region string) error {
 
 	for _, service := range resp.Services {
 		if strings.HasPrefix(service.Name, "test") || strings.HasPrefix(service.Name, "tf-") {
+			log.Printf("Destroying service %s (%s)", service.Name, service.ID)
 			if _, err := client.Services.Delete(service.ID); err != nil {
 				return err
 			}

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepService(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Services.List(&pagerduty.ListServicesOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, service := range resp.Services {
+		if strings.HasPrefix(service.Name, "test") || strings.HasPrefix(service.Name, "tf-") {
+			if _, err := client.Services.Delete(service.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutyService_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepTeam(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepTeam(region string) error {
 
 	for _, team := range resp.Teams {
 		if strings.HasPrefix(team.Name, "test") || strings.HasPrefix(team.Name, "tf-") {
+			log.Printf("Destroying team %s (%s)", team.Name, team.ID)
 			if _, err := client.Teams.Delete(team.ID); err != nil {
 				return err
 			}

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepTeam(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Teams.List(&pagerduty.ListTeamsOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, team := range resp.Teams {
+		if strings.HasPrefix(team.Name, "test") || strings.HasPrefix(team.Name, "tf-") {
+			if _, err := client.Teams.Delete(team.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutyTeam_Basic(t *testing.T) {
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -9,6 +10,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
+
+func testSweepUser(region string) error {
+	client, err := sweeperClient()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Users.List(&pagerduty.ListUsersOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, user := range resp.Users {
+		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf-") {
+			if _, err := client.Users.Delete(user.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func TestAccPagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -12,7 +13,12 @@ import (
 )
 
 func testSweepUser(region string) error {
-	client, err := sweeperClient()
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
 	if err != nil {
 		return err
 	}
@@ -24,6 +30,7 @@ func testSweepUser(region string) error {
 
 	for _, user := range resp.Users {
 		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf-") {
+			log.Printf("Destroying user %s (%s)", user.Name, user.ID)
 			if _, err := client.Users.Delete(user.ID); err != nil {
 				return err
 			}

--- a/pagerduty/sweeper_test.go
+++ b/pagerduty/sweeper_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -45,6 +46,10 @@ func TestMain(m *testing.M) {
 }
 
 func sweeperClient() (*pagerduty.Client, error) {
+	if os.Getenv("PAGERDUTY_SWEEPER_TOKEN") == "" {
+		return nil, fmt.Errorf("$PAGERDUTY_SWEEPER_TOKEN must be set")
+	}
+
 	config := &pagerduty.Config{
 		Token: os.Getenv("PAGERDUTY_SWEEPER_TOKEN"),
 		Debug: true,

--- a/pagerduty/sweeper_test.go
+++ b/pagerduty/sweeper_test.go
@@ -26,7 +26,7 @@ func init() {
 	})
 
 	resource.AddTestSweepers("pagerduty_team", &resource.Sweeper{
-		Name: "pagerdutypagerduty_team_user",
+		Name: "pagerduty_team",
 		F:    testSweepTeam,
 	})
 

--- a/pagerduty/sweeper_test.go
+++ b/pagerduty/sweeper_test.go
@@ -1,0 +1,54 @@
+package pagerduty
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_service", &resource.Sweeper{
+		Name: "pagerduty_service",
+		F:    testSweepService,
+	})
+
+	resource.AddTestSweepers("pagerduty_escalation_policy", &resource.Sweeper{
+		Name: "pagerduty_escalation_policy",
+		F:    testSweepEscalationPolicy,
+	})
+
+	resource.AddTestSweepers("pagerduty_user", &resource.Sweeper{
+		Name: "pagerduty_user",
+		F:    testSweepUser,
+	})
+
+	resource.AddTestSweepers("pagerduty_team", &resource.Sweeper{
+		Name: "pagerdutypagerduty_team_user",
+		F:    testSweepTeam,
+	})
+
+	resource.AddTestSweepers("pagerduty_schedule", &resource.Sweeper{
+		Name: "pagerduty_schedule",
+		F:    testSweepSchedule,
+	})
+
+	resource.AddTestSweepers("pagerduty_addon", &resource.Sweeper{
+		Name: "pagerduty_addon",
+		F:    testSweepAddon,
+	})
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sweeperClient() (*pagerduty.Client, error) {
+	config := &pagerduty.Config{
+		Token: os.Getenv("PAGERDUTY_SWEEPER_TOKEN"),
+		Debug: true,
+	}
+
+	return pagerduty.NewClient(config)
+}

--- a/pagerduty/sweeper_test.go
+++ b/pagerduty/sweeper_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 func init() {
@@ -45,15 +44,16 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-func sweeperClient() (*pagerduty.Client, error) {
+// sharedConfigForRegion returns a common config setup needed for the sweeper
+// functions for a given region
+func sharedConfigForRegion(region string) (*Config, error) {
 	if os.Getenv("PAGERDUTY_SWEEPER_TOKEN") == "" {
 		return nil, fmt.Errorf("$PAGERDUTY_SWEEPER_TOKEN must be set")
 	}
 
-	config := &pagerduty.Config{
+	config := &Config{
 		Token: os.Getenv("PAGERDUTY_SWEEPER_TOKEN"),
-		Debug: true,
 	}
 
-	return pagerduty.NewClient(config)
+	return config, nil
 }


### PR DESCRIPTION
This PR adds support for sweeper.

Tests are passing:
```bash
TF_ACC=1 go test ./pagerduty -v -sweep=pg-east -timeout 120m
2017/06/29 00:57:10 [DEBUG] Running Sweepers for region (pg-east):
2017/06/29 00:57:14 Destroying user tf-123 (AAAAAA)
2017/06/29 00:57:15 Destroying user tf-234 (BBBBBB)
2017/06/29 00:57:24 Sweeper Tests ran:
	- pagerduty_team
	- pagerduty_schedule
	- pagerduty_addon
	- pagerduty_service
	- pagerduty_escalation_policy
	- pagerduty_user
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	13.935s
```