### PR TITLE
New resource: pagerduty_team_membership

### DIFF
--- a/pagerduty/import_pagerduty_team_membership_test.go
+++ b/pagerduty/import_pagerduty_team_membership_test.go
@@ -1,0 +1,31 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPagerDutyTeamMembership_import(t *testing.T) {
+	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipConfig(user, team),
+			},
+
+			{
+				ResourceName:      "pagerduty_team_membership.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -39,6 +39,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_service_integration": resourcePagerDutyServiceIntegration(),
 			"pagerduty_service":             resourcePagerDutyService(),
 			"pagerduty_team":                resourcePagerDutyTeam(),
+			"pagerduty_team_membership":     resourcePagerDutyTeamMembership(),
 			"pagerduty_user":                resourcePagerDutyUser(),
 		},
 

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -1,0 +1,105 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyTeamMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyTeamMembershipCreate,
+		Read:   resourcePagerDutyTeamMembershipRead,
+		Delete: resourcePagerDutyTeamMembershipDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+func resourcePagerDutyTeamMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	userID := d.Get("user_id").(string)
+	teamID := d.Get("team_id").(string)
+
+	log.Printf("[DEBUG] Adding user: %s to team: %s", userID, teamID)
+
+	if _, err := client.Teams.AddUser(teamID, userID); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", userID, teamID))
+
+	return resourcePagerDutyTeamMembershipRead(d, meta)
+}
+
+func resourcePagerDutyTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	userID, teamID := resourcePagerDutyTeamMembershipParseID(d.Id())
+
+	log.Printf("[DEBUG] Reading user: %s from team: %s", userID, teamID)
+
+	user, _, err := client.Users.Get(userID, &pagerduty.GetUserOptions{})
+	if err != nil {
+		return err
+	}
+
+	if !isTeamMember(user, teamID) {
+		log.Printf("[WARN] Removing %s since the user: %s is not a member of: %s", d.Id(), userID, teamID)
+		d.SetId("")
+	}
+
+	d.Set("user_id", userID)
+	d.Set("team_id", teamID)
+
+	return nil
+}
+
+func resourcePagerDutyTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	userID, teamID := resourcePagerDutyTeamMembershipParseID(d.Id())
+
+	log.Printf("[DEBUG] Removing user: %s from team: %s", userID, teamID)
+
+	if _, err := client.Teams.RemoveUser(teamID, userID); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourcePagerDutyTeamMembershipParseID(id string) (string, string) {
+	parts := strings.Split(id, ":")
+	return parts[0], parts[1]
+}
+
+func isTeamMember(user *pagerduty.User, teamID string) bool {
+	var found bool
+
+	for _, team := range user.Teams {
+		if teamID == team.ID {
+			found = true
+		}
+	}
+
+	return found
+}

--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -1,0 +1,96 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func TestAccPagerDutyTeamMembership_Basic(t *testing.T) {
+	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipConfig(user, team),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyTeamMembershipDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_team_membership" {
+			continue
+		}
+
+		user, _, err := client.Users.Get(r.Primary.Attributes["user_id"], &pagerduty.GetUserOptions{})
+		if err == nil {
+			if isTeamMember(user, r.Primary.Attributes["team_id"]) {
+				return fmt.Errorf("%s is still a member of: %s", user.ID, r.Primary.Attributes["team_id"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckPagerDutyTeamMembershipExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*pagerduty.Client)
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		userID := rs.Primary.Attributes["user_id"]
+		teamID := rs.Primary.Attributes["team_id"]
+
+		user, _, err := client.Users.Get(userID, &pagerduty.GetUserOptions{})
+		if err != nil {
+			return err
+		}
+
+		if !isTeamMember(user, teamID) {
+			return fmt.Errorf("%s is not a member of: %s", userID, teamID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyTeamMembershipConfig(user, team string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name = "%[1]v"
+  email = "%[1]v@foo.com"
+}
+
+resource "pagerduty_team" "foo" {
+  name        = "%[2]v"
+  description = "foo"
+}
+
+resource "pagerduty_team_membership" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  team_id = "${pagerduty_team.foo.id}"
+}
+`, user, team)
+}

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_team_membership"
+sidebar_current: "docs-pagerduty-resource-team-membership"
+description: |-
+  Creates and manages a team membership in PagerDuty.
+---
+
+# pagerduty_team_membership
+
+A [team membership](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Teams/put_teams_id_users_user_id) manages memberships within a team.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_user" "foo" {
+  name = "foo"
+  email = "foo@bar.com"
+}
+
+resource "pagerduty_team" "foo" {
+  name        = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_team_membership" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  team_id = "${pagerduty_team.foo.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `user_id` - (Required) The ID of the user to add to the team.
+  * `team_id` - (Required) The ID of the team in which the user will belong.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `user_id` - The ID of the user belonging to the team.
+  * `team_id` - The team ID the user belongs to.
+
+
+## Import
+
+Team memberships can be imported using the `user_id` and `team_id`, e.g.
+
+```
+$ terraform import pagerduty_team_membership.main PLBP09X:PLB09Z
+```

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -40,6 +40,9 @@
                 <li<%= sidebar_current("docs-pagerduty-resource-team") %>>
                     <a href="/docs/providers/pagerduty/r/team.html">pagerduty_team</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-team-membership") %>>
+                    <a ref="/docs/providers/pagerduty/r/team_membership.html">pagerduty_team_membership</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-escalation_policy") %>>
                     <a href="/docs/providers/pagerduty/r/escalation_policy.html">pagerduty_escalation_policy</a>
                 </li>


### PR DESCRIPTION
This PR adds support for managing team memberships as a separate resource. 

There's already a possibility to manage this today in `pagerduty_user`, 
but this allows users to manage the actual membership outside of the user directly.