### PR TITLE
r/pagerdy_service_integration: Protect against panics on imports

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -141,8 +141,15 @@ func resourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interf
 
 	d.Set("name", serviceIntegration.Name)
 	d.Set("type", serviceIntegration.Type)
-	d.Set("service", serviceIntegration.Service.ID)
-	d.Set("vendor", serviceIntegration.Vendor.ID)
+
+	if serviceIntegration.Service != nil {
+		d.Set("service", serviceIntegration.Service.ID)
+	}
+
+	if serviceIntegration.Vendor != nil {
+		d.Set("vendor", serviceIntegration.Vendor.ID)
+	}
+
 	d.Set("integration_key", serviceIntegration.IntegrationKey)
 	d.Set("integration_email", serviceIntegration.IntegrationEmail)
 


### PR DESCRIPTION
In some cases importing a `pagerduty_service_integration` will panic from a nil struct in the SDK response. Should protect against the panic, regardless of whether the returned value should be nil or not.

Fixes: #8 