### PR TITLE
Add support for managing maintenance windows 

### DIFF
--- a/pagerduty/import_pagerduty_maintenance_window_test.go
+++ b/pagerduty/import_pagerduty_maintenance_window_test.go
@@ -1,0 +1,33 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPagerDutyMaintenanceWindow_import(t *testing.T) {
+	window := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	windowStartTime := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	windowEndTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyMaintenanceWindowConfig(window, windowStartTime, windowEndTime),
+			},
+
+			{
+				ResourceName:      "pagerduty_maintenance_window.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -35,9 +35,10 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"pagerduty_addon":               resourcePagerDutyAddon(),
 			"pagerduty_escalation_policy":   resourcePagerDutyEscalationPolicy(),
+			"pagerduty_maintenance_window":  resourcePagerDutyMaintenanceWindow(),
 			"pagerduty_schedule":            resourcePagerDutySchedule(),
-			"pagerduty_service_integration": resourcePagerDutyServiceIntegration(),
 			"pagerduty_service":             resourcePagerDutyService(),
+			"pagerduty_service_integration": resourcePagerDutyServiceIntegration(),
 			"pagerduty_team":                resourcePagerDutyTeam(),
 			"pagerduty_team_membership":     resourcePagerDutyTeamMembership(),
 			"pagerduty_user":                resourcePagerDutyUser(),

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -18,13 +18,14 @@ func resourcePagerDutyMaintenanceWindow() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"start_time": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateRFC3339,
 			},
-
 			"end_time": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateRFC3339,
 			},
 
 			"services": {

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -1,0 +1,147 @@
+package pagerduty
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyMaintenanceWindow() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyMaintenanceWindowCreate,
+		Read:   resourcePagerDutyMaintenanceWindowRead,
+		Update: resourcePagerDutyMaintenanceWindowUpdate,
+		Delete: resourcePagerDutyMaintenanceWindowDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"end_time": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"services": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+		},
+	}
+}
+
+func buildMaintenanceWindowStruct(d *schema.ResourceData) *pagerduty.MaintenanceWindow {
+	window := &pagerduty.MaintenanceWindow{
+		StartTime: d.Get("start_time").(string),
+		EndTime:   d.Get("end_time").(string),
+		Services:  expandServices(d.Get("services")),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		window.Description = v.(string)
+	}
+
+	return window
+}
+
+func resourcePagerDutyMaintenanceWindowCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	window := buildMaintenanceWindowStruct(d)
+
+	log.Printf("[INFO] Creating PagerDuty maintenance window")
+
+	window, _, err := client.MaintenanceWindows.Create(window)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(window.ID)
+
+	return nil
+}
+
+func resourcePagerDutyMaintenanceWindowRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty maintenance window %s", d.Id())
+
+	window, _, err := client.MaintenanceWindows.Get(d.Id())
+	if err != nil {
+		return handleNotFoundError(err, d)
+	}
+
+	d.Set("description", window.Description)
+	d.Set("start_time", window.StartTime)
+	d.Set("end_time", window.EndTime)
+
+	if err := d.Set("services", flattenServices(window.Services)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourcePagerDutyMaintenanceWindowUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	window := buildMaintenanceWindowStruct(d)
+
+	log.Printf("[INFO] Updating PagerDuty maintenance window %s", d.Id())
+
+	if _, _, err := client.MaintenanceWindows.Update(d.Id(), window); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourcePagerDutyMaintenanceWindowDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Deleting PagerDuty maintenance window %s", d.Id())
+
+	if _, err := client.MaintenanceWindows.Delete(d.Id()); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func expandServices(v interface{}) []*pagerduty.ServiceReference {
+	var services []*pagerduty.ServiceReference
+
+	for _, srv := range v.([]interface{}) {
+		service := &pagerduty.ServiceReference{
+			Type: "service_reference",
+			ID:   srv.(string),
+		}
+		services = append(services, service)
+	}
+
+	return services
+}
+
+func flattenServices(v []*pagerduty.ServiceReference) []interface{} {
+	var services []interface{}
+
+	for _, srv := range v {
+		services = append(services, srv.ID)
+	}
+
+	return services
+}

--- a/pagerduty/resource_pagerduty_maintenance_window_test.go
+++ b/pagerduty/resource_pagerduty_maintenance_window_test.go
@@ -1,0 +1,208 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func testSweepMaintenanceWindow(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.MaintenanceWindows.List(&pagerduty.ListMaintenanceWindowsOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, window := range resp.MaintenanceWindows {
+		if strings.HasPrefix(window.Description, "test") || strings.HasPrefix(window.Description, "tf-") {
+			log.Printf("Destroying maintenance window %s (%s)", window.Description, window.ID)
+			if _, err := client.MaintenanceWindows.Delete(window.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyMaintenanceWindow_Basic(t *testing.T) {
+	window := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	windowStartTime := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
+	windowEndTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	windowUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	windowUpdatedStartTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	windowUpdatedEndTime := time.Now().Add(72 * time.Hour).Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyAddonDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyMaintenanceWindowConfig(window, windowStartTime, windowEndTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyMaintenanceWindowExists("pagerduty_maintenance_window.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyMaintenanceWindowConfigUpdated(windowUpdated, windowUpdatedStartTime, windowUpdatedEndTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyMaintenanceWindowExists("pagerduty_maintenance_window.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyMaintenanceWindowDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_maintenance_windodw" {
+			continue
+		}
+
+		if _, _, err := client.MaintenanceWindows.Get(r.Primary.ID); err == nil {
+			return fmt.Errorf("maintenance window still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyMaintenanceWindowExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No maintenance window ID is set")
+		}
+
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		found, _, err := client.MaintenanceWindows.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("maintenacne window not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyMaintenanceWindowConfig(desc, start, end string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[1]v@foo.com"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%[1]v"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%[1]v"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_maintenance_window" "foo" {
+  description = "%[1]v"
+  start_time  = "%[2]v"
+  end_time    = "%[3]v"
+  services    = ["${pagerduty_service.foo.id}"]
+}
+`, desc, start, end)
+}
+
+func testAccCheckPagerDutyMaintenanceWindowConfigUpdated(desc, start, end string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[1]v@foo.com"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%[1]v"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%[1]v"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_maintenance_window" "foo" {
+  description = "%[1]v"
+  start_time  = "%[2]v"
+  end_time    = "%[3]v"
+  services    = ["${pagerduty_service.foo.id}"]
+}
+`, desc, start, end)
+}

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -2,9 +2,20 @@ package pagerduty
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
+
+// validateRFC3339 validates that a date string has the correct RFC3339 layout
+func validateRFC3339(v interface{}, k string) (we []string, errors []error) {
+	value := v.(string)
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		errors = append(errors, fmt.Errorf("%s is not a valid format for argument: %s. Expected format: %s (RFC3339)", value, k, time.RFC3339))
+	}
+
+	return
+}
 
 // Validate a value against a set of possible values
 func validateValueFunc(values []string) schema.SchemaValidateFunc {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/addon.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/addon.go
@@ -31,10 +31,10 @@ type ListAddonsOptions struct {
 
 // ListAddonsResponse represents a list response of add-ons.
 type ListAddonsResponse struct {
-	Limit  int      `url:"limit,omitempty"`
-	More   bool     `url:"more,omitempty"`
-	Offset int      `url:"offset,omitempty"`
-	Total  int      `url:"total,omitempty"`
+	Limit  int      `json:"limit,omitempty"`
+	More   bool     `json:"more,omitempty"`
+	Offset int      `json:"offset,omitempty"`
+	Total  int      `json:"total,omitempty"`
 	Addons []*Addon `json:"addons,omitempty"`
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
@@ -32,19 +32,19 @@ type EscalationPolicy struct {
 
 // ListEscalationPoliciesResponse represents a list response of escalation policies.
 type ListEscalationPoliciesResponse struct {
-	Limit              int                 `url:"limit,omitempty"`
-	More               bool                `url:"more,omitempty"`
-	Offset             int                 `url:"offset,omitempty"`
-	Total              int                 `url:"total,omitempty"`
+	Limit              int                 `json:"limit,omitempty"`
+	More               bool                `json:"more,omitempty"`
+	Offset             int                 `json:"offset,omitempty"`
+	Total              int                 `json:"total,omitempty"`
 	EscalationPolicies []*EscalationPolicy `json:"escalation_policies,omitempty"`
 }
 
 // ListEscalationRulesResponse represents a list response of escalation rules.
 type ListEscalationRulesResponse struct {
-	Limit           int               `url:"limit,omitempty"`
-	More            bool              `url:"more,omitempty"`
-	Offset          int               `url:"offset,omitempty"`
-	Total           int               `url:"total,omitempty"`
+	Limit           int               `json:"limit,omitempty"`
+	More            bool              `json:"more,omitempty"`
+	Offset          int               `json:"offset,omitempty"`
+	Total           int               `json:"total,omitempty"`
 	EscalationRules []*EscalationRule `json:"escalation_rules,omitempty"`
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/maintenance_window.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/maintenance_window.go
@@ -1,0 +1,100 @@
+package pagerduty
+
+import "fmt"
+
+// MaintenanceWindowService handles the communication with add-on related methods
+// of the PagerDuty API.
+type MaintenanceWindowService service
+
+// MaintenanceWindow represents a PagerDuty maintenance window.
+type MaintenanceWindow struct {
+	CreatedBy         *UserReference      `json:"created_by,omitempty"`
+	Description       string              `json:"description,omitempty"`
+	EndTime           string              `json:"end_time,omitempty"`
+	HTMLURL           string              `json:"html_url,omitempty"`
+	ID                string              `json:"id,omitempty"`
+	MaintenanceWindow *MaintenanceWindow  `json:"maintenance_window,omitempty"`
+	Self              string              `json:"self,omitempty"`
+	SequenceNumber    int                 `json:"sequence_number,omitempty"`
+	Services          []*ServiceReference `json:"services,omitempty"`
+	Src               string              `json:"src,omitempty"`
+	StartTime         string              `json:"start_time,omitempty"`
+	Summary           string              `json:"summary,omitempty"`
+	Teams             []*TeamReference    `json:"teams,omitempty"`
+	Type              string              `json:"type,omitempty"`
+}
+
+// ListMaintenanceWindowsOptions represents options when listing maintenance windows.
+type ListMaintenanceWindowsOptions struct {
+	Filter     string   `url:"filter,omitempty"`
+	Include    []string `url:"include,omitempty,brackets"`
+	Query      string   `url:"query,omitempty"`
+	ServiceIDs []string `url:"service_ids,omitempty,brackets"`
+	TeamIDs    []string `url:"team_ids,omitempty,brackets"`
+}
+
+// ListMaintenanceWindowsResponse represents a list response of maintenance windows.
+type ListMaintenanceWindowsResponse struct {
+	Limit              int                  `json:"limit,omitempty"`
+	MaintenanceWindows []*MaintenanceWindow `json:"maintenance_windows,omitempty"`
+	More               bool                 `json:"more,omitempty"`
+	Offset             int                  `json:"offset,omitempty"`
+	Total              int                  `json:"total,omitempty"`
+}
+
+// List lists existing maintenance windows.
+func (s *MaintenanceWindowService) List(o *ListMaintenanceWindowsOptions) (*ListMaintenanceWindowsResponse, *Response, error) {
+	u := "/maintenance_windows"
+	v := new(ListMaintenanceWindowsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Create creates a new maintenancce window.
+func (s *MaintenanceWindowService) Create(maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *Response, error) {
+	u := "/maintenance_windows"
+	v := new(MaintenanceWindow)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, &MaintenanceWindow{MaintenanceWindow: maintenanceWindow}, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.MaintenanceWindow, resp, nil
+}
+
+// Delete removes an existing maintenance window.
+func (s *MaintenanceWindowService) Delete(id string) (*Response, error) {
+	u := fmt.Sprintf("/maintenance_windows/%s", id)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// Get retrieves information about a maintenance window.
+func (s *MaintenanceWindowService) Get(id string) (*MaintenanceWindow, *Response, error) {
+	u := fmt.Sprintf("/maintenance_windows/%s", id)
+	v := new(MaintenanceWindow)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.MaintenanceWindow, resp, nil
+}
+
+// Update updates an existing maintenance window.
+func (s *MaintenanceWindowService) Update(id string, maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *Response, error) {
+	u := fmt.Sprintf("/maintenance_windows/%s", id)
+	v := new(MaintenanceWindow)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &MaintenanceWindow{MaintenanceWindow: maintenanceWindow}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.MaintenanceWindow, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -37,6 +37,7 @@ type Client struct {
 	Abilities          *AbilityService
 	Addons             *AddonService
 	EscalationPolicies *EscalationPolicyService
+	MaintenanceWindows *MaintenanceWindowService
 	Schedules          *ScheduleService
 	Services           *ServicesService
 	Teams              *TeamService
@@ -73,6 +74,7 @@ func NewClient(config *Config) (*Client, error) {
 	c.Abilities = &AbilityService{c}
 	c.Addons = &AddonService{c}
 	c.EscalationPolicies = &EscalationPolicyService{c}
+	c.MaintenanceWindows = &MaintenanceWindowService{c}
 	c.Schedules = &ScheduleService{c}
 	c.Services = &ServicesService{c}
 	c.Teams = &TeamService{c}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
@@ -9,6 +9,15 @@ import (
 // related methods of the PagerDuty API.
 type ScheduleService service
 
+// Override represents an override
+type Override struct {
+	Override *Override      `json:"override,omitempty"`
+	ID       string         `json:"id,omitempty"`
+	Start    string         `json:"start,omitempty"`
+	End      string         `json:"end,omitempty"`
+	User     *UserReference `json:"user,omitempty"`
+}
+
 // Schedule represents a schedule.
 type Schedule struct {
 	Description          string                       `json:"description,omitempty"`
@@ -68,17 +77,47 @@ type ListSchedulesOptions struct {
 	Limit  int    `url:"limit,omitempty"`
 	More   bool   `url:"more,omitempty"`
 	Offset int    `url:"offset,omitempty"`
-	Total  int    `url:"total,omitempty"`
 	Query  string `url:"query,omitempty"`
+	Total  int    `url:"total,omitempty"`
 }
 
 // ListSchedulesResponse represents a list response of schedules.
 type ListSchedulesResponse struct {
-	Limit     int         `url:"limit,omitempty"`
-	More      bool        `url:"more,omitempty"`
-	Offset    int         `url:"offset,omitempty"`
-	Total     int         `url:"total,omitempty"`
+	Limit     int         `json:"limit,omitempty"`
+	More      bool        `json:"more,omitempty"`
+	Offset    int         `json:"offset,omitempty"`
 	Schedules []*Schedule `json:"schedules,omitempty"`
+	Total     int         `json:"total,omitempty"`
+}
+
+// ListOnCallsOptions represents options when listing on calls.
+type ListOnCallsOptions struct {
+	ID    string `url:"id,omitempty"`
+	Since string `url:"since,omitempty"`
+	Until string `url:"until,omitempty"`
+}
+
+// ListOnCallsResponse represents a list response of on calls.
+type ListOnCallsResponse struct {
+	Users []*User `json:"users,omitempty"`
+}
+
+// ListOverridesOptions represents options when listing overrides.
+type ListOverridesOptions struct {
+	Editable bool   `url:"editable,omitempty"`
+	ID       string `url:"id,omitempty"`
+	Overflow bool   `url:"overflow,omitempty"`
+	Since    string `url:"since,omitempty"`
+	Until    string `url:"until,omitempty"`
+}
+
+// ListOverridesResponse represents a list response of schedules.
+type ListOverridesResponse struct {
+	Limit     int         `json:"limit,omitempty"`
+	More      bool        `json:"more,omitempty"`
+	Offset    int         `json:"offset,omitempty"`
+	Overrides []*Override `json:"overrides,omitempty"`
+	Total     int         `json:"total,omitempty"`
 }
 
 // GetScheduleOptions represents options when retrieving a schedule.
@@ -161,6 +200,51 @@ func (s *ScheduleService) Update(id string, schedule *Schedule) (*Schedule, *Res
 	}
 
 	return v.Schedule, resp, nil
+}
+
+// ListOnCalls lists all of the users on call in a given schedule for a given time range.
+func (s *ScheduleService) ListOnCalls(scheduleID string, o *ListOnCallsOptions) (*ListOnCallsResponse, *Response, error) {
+	u := fmt.Sprintf("/schedules/%s/users", scheduleID)
+	v := new(ListOnCallsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// ListOverrides lists existing overrides.
+func (s *ScheduleService) ListOverrides(scheduleID string, o *ListOverridesOptions) (*ListOverridesResponse, *Response, error) {
+	u := fmt.Sprintf("/schedules/%s/overrides", scheduleID)
+	v := new(ListOverridesResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// CreateOverride creates an override for a specific user covering the specified time range.
+func (s *ScheduleService) CreateOverride(id string, override *Override) (*Override, *Response, error) {
+	u := fmt.Sprintf("/schedules/%s/overrides", id)
+	v := new(Override)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, &Override{Override: override}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Override, resp, nil
+}
+
+// DeleteOverride deletes an override.
+func (s *ScheduleService) DeleteOverride(id string, overrideID string) (*Response, error) {
+	u := fmt.Sprintf("/schedules/%s/overrides/%s", id, overrideID)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
 }
 
 func normalizeTime(l *ScheduleLayer) error {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -103,10 +103,10 @@ type ListServicesOptions struct {
 
 // ListServicesResponse represents a list response of services.
 type ListServicesResponse struct {
-	Limit    int  `url:"limit,omitempty"`
-	More     bool `url:"more,omitempty"`
-	Offset   int  `url:"offset,omitempty"`
-	Total    int  `url:"total,omitempty"`
+	Limit    int  `json:"limit,omitempty"`
+	More     bool `json:"more,omitempty"`
+	Offset   int  `json:"offset,omitempty"`
+	Total    int  `json:"total,omitempty"`
 	Services []*Service
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
@@ -29,10 +29,10 @@ type ListTeamsOptions struct {
 
 // ListTeamsResponse represents a list response of teams.
 type ListTeamsResponse struct {
-	Limit  int     `url:"limit,omitempty"`
-	More   bool    `url:"more,omitempty"`
-	Offset int     `url:"offset,omitempty"`
-	Total  int     `url:"total,omitempty"`
+	Limit  int     `json:"limit,omitempty"`
+	More   bool    `json:"more,omitempty"`
+	Offset int     `json:"offset,omitempty"`
+	Total  int     `json:"total,omitempty"`
 	Teams  []*Team `json:"teams,omitempty"`
 }
 
@@ -103,5 +103,17 @@ func (s *TeamService) RemoveUser(teamID, userID string) (*Response, error) {
 // AddUser adds a user to a team.
 func (s *TeamService) AddUser(teamID, userID string) (*Response, error) {
 	u := fmt.Sprintf("/teams/%s/users/%s", teamID, userID)
+	return s.client.newRequestDo("PUT", u, nil, nil, nil)
+}
+
+// RemoveEscalationPolicy removes an escalation policy from a team.
+func (s *TeamService) RemoveEscalationPolicy(teamID, escID string) (*Response, error) {
+	u := fmt.Sprintf("/teams/%s/escalation_policies/%s", teamID, escID)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// AddEscalationPolicy adds an escalation policy to a team.
+func (s *TeamService) AddEscalationPolicy(teamID, escID string) (*Response, error) {
+	u := fmt.Sprintf("/teams/%s/escalation_policies/%s", teamID, escID)
 	return s.client.newRequestDo("PUT", u, nil, nil, nil)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
@@ -40,6 +40,46 @@ type User struct {
 	User              *User                     `json:"user,omitempty"`
 }
 
+// ContactMethod represents a contact method for a user.
+type ContactMethod struct {
+	ContactMethod *ContactMethod `json:"contact_method,omitempty"`
+	ID            string         `json:"id,omitempty"`
+	Summary       string         `json:"summary,omitempty"`
+	Type          string         `json:"type,omitempty"`
+	Self          string         `json:"self,omitempty"`
+	HTMLURL       string         `json:"html_url,omitempty"`
+	Label         string         `json:"label,omitempty"`
+	Address       string         `json:"address,omitempty"`
+	BlackListed   bool           `json:"blacklisted,omitempty"`
+
+	// Email contact method options
+	SendShortEmail bool `json:"send_short_email,omitempty"`
+
+	// Phone contact method options
+	CountryCode int  `json:"country_code,omitempty"`
+	Enabled     bool `json:"enabled,omitempty"`
+
+	// Push contact method options
+	DeviceType string                    `json:"device_type,omitempty"`
+	Sounds     []*PushContactMethodSound `json:"sounds,omitempty"`
+	CreatedAt  string                    `json:"created_at,omitempty"`
+}
+
+// PushContactMethodSound represents a sound for a push contact method.
+type PushContactMethodSound struct {
+	Type string `json:"type,omitempty"`
+	File string `json:"file,omitempty"`
+}
+
+// ListContactMethodsResponse represents
+type ListContactMethodsResponse struct {
+	Limit  int     `json:"limit,omitempty"`
+	More   bool    `json:"more,omitempty"`
+	Offset int     `json:"offset,omitempty"`
+	Total  int     `json:"total,omitempty"`
+	Users  []*User `json:"users,omitempty"`
+}
+
 // ListUsersOptions represents options when listing users.
 type ListUsersOptions struct {
 	Limit   int      `url:"limit,omitempty"`
@@ -53,10 +93,10 @@ type ListUsersOptions struct {
 
 // ListUsersResponse represents a list response of users.
 type ListUsersResponse struct {
-	Limit  int     `url:"limit,omitempty"`
-	More   bool    `url:"more,omitempty"`
-	Offset int     `url:"offset,omitempty"`
-	Total  int     `url:"total,omitempty"`
+	Limit  int     `json:"limit,omitempty"`
+	More   bool    `json:"more,omitempty"`
+	Offset int     `json:"offset,omitempty"`
+	Total  int     `json:"total,omitempty"`
 	Users  []*User `json:"users,omitempty"`
 }
 
@@ -121,4 +161,62 @@ func (s *UserService) Update(id string, user *User) (*User, *Response, error) {
 	}
 
 	return v.User, resp, nil
+}
+
+// ListContactMethods lists contact methods for a user.
+func (s *UserService) ListContactMethods(userID string) (*ListContactMethodsResponse, *Response, error) {
+	u := fmt.Sprintf("/users/%s/contact_methods", userID)
+	v := new(ListContactMethodsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// CreateContactMethod creates a new contact method for a user.
+func (s *UserService) CreateContactMethod(userID string, contactMethod *ContactMethod) (*ContactMethod, *Response, error) {
+	u := fmt.Sprintf("/users/%s/contact_methods", userID)
+	v := new(ContactMethod)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, &ContactMethod{ContactMethod: contactMethod}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.ContactMethod, resp, nil
+}
+
+// GetContactMethod retrieves a contact method for a user.
+func (s *UserService) GetContactMethod(userID string, contactMethodID string) (*ContactMethod, *Response, error) {
+	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
+	v := new(ContactMethod)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.ContactMethod, resp, nil
+}
+
+// UpdateContactMethod updates a contact method for a user.
+func (s *UserService) UpdateContactMethod(userID, contactMethodID string, contactMethod *ContactMethod) (*ContactMethod, *Response, error) {
+	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
+	v := new(ContactMethod)
+
+	resp, err := s.client.newRequestDo("PUT", u, nil, &ContactMethod{ContactMethod: contactMethod}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.ContactMethod, resp, nil
+}
+
+// DeleteContactMethod deletes a contact method for a user.
+func (s *UserService) DeleteContactMethod(userID, contactMethodID string) (*Response, error) {
+	u := fmt.Sprintf("/users/%s/contact_methods/%s", userID, contactMethodID)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/vendor.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/vendor.go
@@ -36,10 +36,10 @@ type ListVendorsOptions struct {
 
 // ListVendorsResponse represents a list response of vendors.
 type ListVendorsResponse struct {
-	Limit   int       `url:"limit,omitempty"`
-	More    bool      `url:"more,omitempty"`
-	Offset  int       `url:"offset,omitempty"`
-	Total   int       `url:"total,omitempty"`
+	Limit   int       `json:"limit,omitempty"`
+	More    bool      `json:"more,omitempty"`
+	Offset  int       `json:"offset,omitempty"`
+	Total   int       `json:"total,omitempty"`
 	Vendors []*Vendor `json:"vendors,omitempty"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -496,10 +496,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "ERg1YD7bZcvqsMHOrUpO7MfJXVA=",
+			"checksumSHA1": "wdQsbb7IEdj0riw+WRkysTD5Ri8=",
 			"path": "github.com/heimweh/go-pagerduty/pagerduty",
-			"revision": "88fb561f357fa105b3928cef961ae75820af42af",
-			"revisionTime": "2017-06-29T11:31:45Z"
+			"revision": "2ce083be4d01d28a721911e83a38a780c7633bcc",
+			"revisionTime": "2017-07-07T18:34:57Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",

--- a/website/docs/r/maintenance_window.html.markdown
+++ b/website/docs/r/maintenance_window.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_maintenance_window"
+sidebar_current: "docs-pagerduty-resource-maintenance-window"
+description: |-
+  Creates and manages a maintenance window in PagerDuty.
+---
+
+# pagerduty_maintenance_window
+
+A [maintenance window](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Maintenance_Windows/get_maintenance_windows) is used to temporarily disable one or more services for a set period of time. No incidents will be triggered and no notifications will be received while a service is disabled by a maintenance window.
+
+Maintenance windows are specified to start at a certain time and end after they have begun. Once started, a maintenance window cannot be deleted; it can only be ended immediately to re-enable the service.
+
+
+## Example Usage
+
+```hcl
+resource "pagerduty_maintenance_window" "example" {
+  start_time  = "2015-11-09T20:00:00-05:00"
+  end_time    = "2015-11-09T22:00:00-05:00"
+  services    = ["${pagerduty_service.example.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `start_time`  - (Required) The maintenance window's start time. This is when the services will stop creating incidents. If this date is in the past, it will be updated to be the current time.
+  * `end_time`    - (Required) The maintenance window's end time. This is when the services will start creating incidents again. This date must be in the future and after the `start_time`.
+  * `services`    - (Required) A list of service IDs to include in the maintenance window.
+  * `description` - (Optional) A description for the maintenance window.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the maintenance window.
+
+
+## Import
+
+Maintenance windows can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_maintenance_window.main PLBP09X
+```

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -13,17 +13,17 @@
         <li<%= sidebar_current("docs-pagerduty-datasource") %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-pagerduty-datasource-user") %>>
-                    <a href="/docs/providers/pagerduty/d/user.html">pagerduty_user</a>
+                <li<%= sidebar_current("docs-pagerduty-datasource-escalation-policy") %>>
+                    <a href="/docs/providers/pagerduty/d/escalation_policy.html">pagerduty_escalation_policy</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-schedule") %>>
                     <a href="/docs/providers/pagerduty/d/schedule.html">pagerduty_schedule</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-user") %>>
+                    <a href="/docs/providers/pagerduty/d/user.html">pagerduty_user</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-vendor") %>>
                     <a href="/docs/providers/pagerduty/d/vendor.html">pagerduty_vendor</a>
-                </li>
-                <li<%= sidebar_current("docs-pagerduty-datasource-escalation-policy") %>>
-                    <a href="/docs/providers/pagerduty/d/escalation_policy.html">pagerduty_escalation_policy</a>
                 </li>
             </ul>
         </li>
@@ -34,17 +34,11 @@
                 <li<%= sidebar_current("docs-pagerduty-resource-addon") %>>
                     <a href="/docs/providers/pagerduty/r/addon.html">pagerduty_addon</a>
                 </li>
-                <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
-                    <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>
-                </li>
-                <li<%= sidebar_current("docs-pagerduty-resource-team") %>>
-                    <a href="/docs/providers/pagerduty/r/team.html">pagerduty_team</a>
-                </li>
-                <li<%= sidebar_current("docs-pagerduty-resource-team-membership") %>>
-                    <a ref="/docs/providers/pagerduty/r/team_membership.html">pagerduty_team_membership</a>
-                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-escalation_policy") %>>
                     <a href="/docs/providers/pagerduty/r/escalation_policy.html">pagerduty_escalation_policy</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-maintenance_window") %>>
+                    <a href="/docs/providers/pagerduty/r/maintenance_window.html">pagerduty_maintenance_window</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-schedule") %>>
                     <a href="/docs/providers/pagerduty/r/schedule.html">pagerduty_schedule</a>
@@ -54,6 +48,15 @@
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-service-integration") %>>
                     <a href="/docs/providers/pagerduty/r/service_integration.html">pagerduty_service_integration</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-team") %>>
+                    <a href="/docs/providers/pagerduty/r/team.html">pagerduty_team</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-team-membership") %>>
+                    <a ref="/docs/providers/pagerduty/r/team_membership.html">pagerduty_team_membership</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
+                    <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>
                 </li>
             </ul>
         </li>


### PR DESCRIPTION
This PR adds support for managing maintenance windows in PagerDuty.

A maintenance window is used to temporarily disable one or more services for a set period of time.

Maintenance windows are specified to start at a certain time and end after they have begun. Once started, a maintenance window cannot be deleted; it can only be ended immediately to re-enable the service.
