### PR TITLE
Remove hardcoded start/end times in tests

### DIFF
--- a/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/pagerduty/data_source_pagerduty_schedule_test.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -14,8 +15,8 @@ func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
-	start := "2020-05-25T02:00:00+02:00"
-	rotationVirtualStart := "2020-05-25T02:00:00+02:00"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/pagerduty/import_pagerduty_maintenance_window_test.go
+++ b/pagerduty/import_pagerduty_maintenance_window_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestAccPagerDutyMaintenanceWindow_import(t *testing.T) {
 	window := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	windowStartTime := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
-	windowEndTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	windowStartTime := timeNowInAccLoc().Add(24 * time.Hour).Format(time.RFC3339)
+	windowEndTime := timeNowInAccLoc().Add(48 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/import_pagerduty_schedule_test.go
+++ b/pagerduty/import_pagerduty_schedule_test.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,8 +14,8 @@ func TestAccPagerDutySchedule_import(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
-	start := "2020-05-12T20:00:00+02:00"
-	rotationVirtualStart := "2020-05-12T20:00:00+02:00"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/provider_test.go
+++ b/pagerduty/provider_test.go
@@ -1,8 +1,10 @@
 package pagerduty
 
 import (
+	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -36,4 +38,29 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("PAGERDUTY_TOKEN"); v == "" {
 		t.Fatal("PAGERDUTY_TOKEN must be set for acceptance tests")
 	}
+}
+
+// timeNowInLoc returns the current time in the given location.
+// If an error occurs when trying to load the location, we just return the current local time.
+func timeNowInLoc(name string) time.Time {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		log.Printf("[WARN] Failed to load location: %s", err)
+		return time.Now()
+	}
+
+	return time.Now().In(loc)
+}
+
+// timeNowInAccLoc returns the current time in the given location.
+// The location defaults to Europe/Dublin but can be controlled by the PAGERDUTY_TIME_ZONE environment variable.
+// The location must match the PagerDuty account time zone or diff issues might bubble up in tests.
+func timeNowInAccLoc() time.Time {
+	name := "Europe/Dublin"
+
+	if v := os.Getenv("PAGERDUTY_TIME_ZONE"); v != "" {
+		name = v
+	}
+
+	return timeNowInLoc(name)
 }

--- a/pagerduty/resource_pagerduty_maintenance_window_test.go
+++ b/pagerduty/resource_pagerduty_maintenance_window_test.go
@@ -43,11 +43,11 @@ func testSweepMaintenanceWindow(region string) error {
 
 func TestAccPagerDutyMaintenanceWindow_Basic(t *testing.T) {
 	window := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	windowStartTime := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
-	windowEndTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	windowStartTime := timeNowInAccLoc().Add(24 * time.Hour).Format(time.RFC3339)
+	windowEndTime := timeNowInAccLoc().Add(48 * time.Hour).Format(time.RFC3339)
 	windowUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	windowUpdatedStartTime := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
-	windowUpdatedEndTime := time.Now().Add(72 * time.Hour).Format(time.RFC3339)
+	windowUpdatedStartTime := timeNowInAccLoc().Add(48 * time.Hour).Format(time.RFC3339)
+	windowUpdatedEndTime := timeNowInAccLoc().Add(72 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -73,7 +73,7 @@ func TestAccPagerDutyMaintenanceWindow_Basic(t *testing.T) {
 func testAccCheckPagerDutyMaintenanceWindowDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*pagerduty.Client)
 	for _, r := range s.RootModule().Resources {
-		if r.Type != "pagerduty_maintenance_windodw" {
+		if r.Type != "pagerduty_maintenance_window" {
 			continue
 		}
 
@@ -104,7 +104,7 @@ func testAccCheckPagerDutyMaintenanceWindowExists(n string) resource.TestCheckFu
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("maintenacne window not found: %v - %v", rs.Primary.ID, found)
+			return fmt.Errorf("maintenance window not found: %v - %v", rs.Primary.ID, found)
 		}
 
 		return nil

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -46,8 +47,8 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "America/New_York"
-	start := "2020-05-12T20:00:00-04:00"
-	rotationVirtualStart := "2020-05-12T20:00:00-04:00"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,8 +105,8 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Australia/Melbourne"
-	start := "2020-05-12T20:00:00+10:00"
-	rotationVirtualStart := "2020-05-12T20:00:00+10:00"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,8 +166,8 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 	email := fmt.Sprintf("%s@foo.com", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
-	start := "2020-05-12T20:00:00+02:00"
-	rotationVirtualStart := "2020-05-12T20:00:00+02:00"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
This PR aims to remove the hardcoded start/end times in the tests to prevent diff issues in maintenance windows and schedules. 

This should resolve the following failing test case by using the correct time zone in tests:
```bash
=== RUN   TestAccPagerDutyMaintenanceWindow_import
--- FAIL: TestAccPagerDutyMaintenanceWindow_import (4.09s)
    testing.go:428: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: pagerduty_maintenance_window.foo
          end_time:   "2017-07-15T06:13:26+01:00" => "2017-07-15T05:13:26Z"
          start_time: "2017-07-14T06:13:26+01:00" => "2017-07-14T05:13:26Z"
```