### PR TITLE
Fix sidebar link for team_membership

### DIFF
--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -53,7 +53,7 @@
                     <a href="/docs/providers/pagerduty/r/team.html">pagerduty_team</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-team-membership") %>>
-                    <a ref="/docs/providers/pagerduty/r/team_membership.html">pagerduty_team_membership</a>
+                    <a href="/docs/providers/pagerduty/r/team_membership.html">pagerduty_team_membership</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
                     <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>


### PR DESCRIPTION
This PR fixes the sidebar link for `pagerduty_team_membership`.