### PR TITLE
r/pagerduty_schedule: Add support for overflow 

### DIFF
--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -7,6 +7,15 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+func timeToUTC(v string) (string, error) {
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return "", err
+	}
+
+	return t.UTC().String(), nil
+}
+
 // validateRFC3339 validates that a date string has the correct RFC3339 layout
 func validateRFC3339(v interface{}, k string) (we []string, errors []error) {
 	value := v.(string)

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
@@ -2,7 +2,6 @@ package pagerduty
 
 import (
 	"fmt"
-	"time"
 )
 
 // ScheduleService handles the communication with schedule
@@ -127,6 +126,11 @@ type GetScheduleOptions struct {
 	Until    string `url:"until,omitempty"`
 }
 
+// CreateScheduleOptions represents options when creating a schedule.
+type CreateScheduleOptions struct {
+	Overflow bool `url:"overflow,omitempty"`
+}
+
 // UpdateScheduleOptions represents options when updating a schedule.
 type UpdateScheduleOptions struct {
 	Overflow bool `url:"overflow,omitempty"`
@@ -146,17 +150,11 @@ func (s *ScheduleService) List(o *ListSchedulesOptions) (*ListSchedulesResponse,
 }
 
 // Create creates a new schedule.
-func (s *ScheduleService) Create(schedule *Schedule) (*Schedule, *Response, error) {
+func (s *ScheduleService) Create(schedule *Schedule, o *CreateScheduleOptions) (*Schedule, *Response, error) {
 	u := "/schedules"
 	v := new(Schedule)
 
-	for _, layer := range schedule.ScheduleLayers {
-		if err := normalizeTime(layer); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	resp, err := s.client.newRequestDo("POST", u, nil, &Schedule{Schedule: schedule}, &v)
+	resp, err := s.client.newRequestDo("POST", u, o, &Schedule{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -184,17 +182,11 @@ func (s *ScheduleService) Get(id string, o *GetScheduleOptions) (*Schedule, *Res
 }
 
 // Update updates an existing schedule.
-func (s *ScheduleService) Update(id string, schedule *Schedule) (*Schedule, *Response, error) {
+func (s *ScheduleService) Update(id string, schedule *Schedule, o *UpdateScheduleOptions) (*Schedule, *Response, error) {
 	u := fmt.Sprintf("/schedules/%s", id)
 	v := new(Schedule)
 
-	for _, layer := range schedule.ScheduleLayers {
-		if err := normalizeTime(layer); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	resp, err := s.client.newRequestDo("PUT", u, nil, &Schedule{Schedule: schedule}, &v)
+	resp, err := s.client.newRequestDo("PUT", u, o, &Schedule{Schedule: schedule}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -245,37 +237,4 @@ func (s *ScheduleService) CreateOverride(id string, override *Override) (*Overri
 func (s *ScheduleService) DeleteOverride(id string, overrideID string) (*Response, error) {
 	u := fmt.Sprintf("/schedules/%s/overrides/%s", id, overrideID)
 	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
-}
-
-func normalizeTime(l *ScheduleLayer) error {
-	s, err := timeToUTC(l.Start)
-	if err != nil {
-		return err
-	}
-	l.Start = s
-
-	rvs, err := timeToUTC(l.RotationVirtualStart)
-	if err != nil {
-		return err
-	}
-	l.RotationVirtualStart = rvs
-
-	if l.End != "" {
-		e, err := timeToUTC(l.End)
-		if err != nil {
-			return err
-		}
-		l.End = e
-	}
-
-	return nil
-}
-
-func timeToUTC(v string) (string, error) {
-	t, err := time.Parse(time.RFC3339, v)
-	if err != nil {
-		return "", err
-	}
-
-	return t.UTC().String(), nil
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
@@ -73,11 +73,11 @@ type PushContactMethodSound struct {
 
 // ListContactMethodsResponse represents
 type ListContactMethodsResponse struct {
-	Limit  int     `json:"limit,omitempty"`
-	More   bool    `json:"more,omitempty"`
-	Offset int     `json:"offset,omitempty"`
-	Total  int     `json:"total,omitempty"`
-	Users  []*User `json:"users,omitempty"`
+	Limit          int              `json:"limit,omitempty"`
+	More           bool             `json:"more,omitempty"`
+	Offset         int              `json:"offset,omitempty"`
+	Total          int              `json:"total,omitempty"`
+	ContactMethods []*ContactMethod `json:"contact_methods,omitempty"`
 }
 
 // ListUsersOptions represents options when listing users.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -496,10 +496,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "wdQsbb7IEdj0riw+WRkysTD5Ri8=",
+			"checksumSHA1": "dUAQZ2MR++DUDweCwlkwvAJRW2c=",
 			"path": "github.com/heimweh/go-pagerduty/pagerduty",
-			"revision": "2ce083be4d01d28a721911e83a38a780c7633bcc",
-			"revisionTime": "2017-07-07T18:34:57Z"
+			"revision": "274147fdf0518851dae256b9a80044a94ab814a3",
+			"revisionTime": "2017-08-09T21:49:27Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",

--- a/website/docs/r/schedule.html.markdown
+++ b/website/docs/r/schedule.html.markdown
@@ -48,6 +48,9 @@ The following arguments are supported:
 * `time_zone` - (Required) The time zone of the schedule (e.g Europe/Berlin).
 * `description` - (Optional) The description of the schedule
 * `layer` - (Required) A schedule layer block. Schedule layers documented below.
+* `overflow` - (Optional) Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter `overflow` is passed. For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from `2011-06-01T10:00:00Z` to `2011-06-01T14:00:00Z`:
+If you don't pass the overflow=true parameter, you will get one schedule entry returned with a start of `2011-06-01T10:00:00Z` and end of `2011-06-01T14:00:00Z`.
+If you do pass the `overflow` parameter, you will get one schedule entry returned with a start of `2011-06-01T00:00:00Z` and end of `2011-06-02T00:00:00Z`.
 
 
 Schedule layers (`layer`) supports the following:


### PR DESCRIPTION
This PR adds support for passing `overflow` when creating/updating schedules.

This PR also fixes a bug when creating/updating schedules (related to `rotation_virtual_start`).

The issue here is that if a user specifies a rotation_virtual_start time to be:
`2017-09-01T10:00:00+02:00` the API returns back:
`2017-09-01T12:00:00+02:00`.

With this fix in place, we get the correct rotation_virtual_start time, thus eliminating diff issues we've been seeing in the past. This has been confirmed working by PagerDuty support.

Fixes: #21 