### PR TITLE
New resource: pagerduty_user_contact_method

### DIFF
--- a/pagerduty/import_pagerduty_user_contact_method_test.go
+++ b/pagerduty/import_pagerduty_user_contact_method_test.go
@@ -1,0 +1,30 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPagerDutyUserContactMethod_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodEmailConfig(username, email),
+			},
+			{
+				ResourceName:      "pagerduty_user_contact_method.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/import_pagerduty_user_contact_method_test.go
+++ b/pagerduty/import_pagerduty_user_contact_method_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyUserContactMethod_import(t *testing.T) {
@@ -22,9 +23,14 @@ func TestAccPagerDutyUserContactMethod_import(t *testing.T) {
 			},
 			{
 				ResourceName:      "pagerduty_user_contact_method.foo",
+				ImportStateIdFunc: testAccCheckPagerDutyUserContactMethodId,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccCheckPagerDutyUserContactMethodId(s *terraform.State) (string, error) {
+	return fmt.Sprintf("%v:%v", s.RootModule().Resources["pagerduty_user.foo"].Primary.ID, s.RootModule().Resources["pagerduty_user_contact_method.foo"].Primary.ID), nil
 }

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -43,6 +43,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_team":                resourcePagerDutyTeam(),
 			"pagerduty_team_membership":     resourcePagerDutyTeamMembership(),
 			"pagerduty_user":                resourcePagerDutyUser(),
+			"pagerduty_user_contact_method": resourcePagerDutyUserContactMethod(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -35,8 +35,9 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 			},
 
 			"send_short_email": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 
 			"country_code": {

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -1,0 +1,173 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyUserContactMethod() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyUserContactMethodCreate,
+		Read:   resourcePagerDutyUserContactMethodRead,
+		Update: resourcePagerDutyUserContactMethodUpdate,
+		Delete: resourcePagerDutyUserContactMethodDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validateValueFunc([]string{
+					"email_contact_method",
+					"phone_contact_method",
+					"sms_contact_method",
+				}),
+			},
+
+			"send_short_email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"country_code": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"blacklisted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"label": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"contact_method_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildUserContactMethodStruct(d *schema.ResourceData) *pagerduty.ContactMethod {
+	contactMethod := &pagerduty.ContactMethod{
+		Type:    d.Get("type").(string),
+		Label:   d.Get("label").(string),
+		Address: d.Get("address").(string),
+	}
+
+	if v, ok := d.GetOk("send_short_email"); ok {
+		contactMethod.SendShortEmail = v.(bool)
+	}
+
+	if v, ok := d.GetOk("country_code"); ok {
+		contactMethod.CountryCode = v.(int)
+	}
+
+	if v, ok := d.GetOk("enabled"); ok {
+		contactMethod.Enabled = v.(bool)
+	}
+
+	return contactMethod
+}
+
+func resourcePagerDutyUserContactMethodParseID(id string) (string, string) {
+	// userID, contactMethodID
+	parts := strings.Split(id, ":")
+	return parts[0], parts[1]
+}
+
+func resourcePagerDutyUserContactMethodCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	userID := d.Get("user_id").(string)
+
+	contactMethod := buildUserContactMethodStruct(d)
+
+	resp, _, err := client.Users.CreateContactMethod(userID, contactMethod)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", userID, resp.ID))
+
+	return resourcePagerDutyUserContactMethodRead(d, meta)
+}
+
+func resourcePagerDutyUserContactMethodRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	userID, cmID := resourcePagerDutyUserContactMethodParseID(d.Id())
+
+	resp, _, err := client.Users.GetContactMethod(userID, cmID)
+	if err != nil {
+		return handleNotFoundError(err, d)
+	}
+
+	d.Set("address", resp.Address)
+	d.Set("blacklisted", resp.BlackListed)
+	d.Set("contact_method_id", resp.ID)
+	d.Set("country_code", resp.CountryCode)
+	d.Set("enabled", resp.Enabled)
+	d.Set("label", resp.Label)
+	d.Set("send_short_email", resp.SendShortEmail)
+	d.Set("type", resp.Type)
+	d.Set("user_id", userID)
+
+	return nil
+}
+
+func resourcePagerDutyUserContactMethodUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	contactMethod := buildUserContactMethodStruct(d)
+
+	log.Printf("[INFO] Updating PagerDuty user contact method %s", d.Id())
+
+	userID, cmID := resourcePagerDutyUserContactMethodParseID(d.Id())
+
+	if _, _, err := client.Users.UpdateContactMethod(userID, cmID, contactMethod); err != nil {
+		return err
+	}
+
+	return resourcePagerDutyUserContactMethodRead(d, meta)
+}
+
+func resourcePagerDutyUserContactMethodDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Deleting PagerDuty user contact method %s", d.Id())
+
+	userID, cmID := resourcePagerDutyUserContactMethodParseID(d.Id())
+
+	if _, err := client.Users.DeleteContactMethod(userID, cmID); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -165,7 +165,7 @@ func resourcePagerDutyUserContactMethodDelete(d *schema.ResourceData, meta inter
 	userID, cmID := resourcePagerDutyUserContactMethodParseID(d.Id())
 
 	if _, err := client.Users.DeleteContactMethod(userID, cmID); err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	d.SetId("")

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -98,9 +98,7 @@ func testAccCheckPagerDutyUserContactMethodDestroy(s *terraform.State) error {
 			continue
 		}
 
-		userID, cmID := resourcePagerDutyUserContactMethodParseID(r.Primary.ID)
-
-		if _, _, err := client.Users.GetContactMethod(userID, cmID); err == nil {
+		if _, _, err := client.Users.GetContactMethod(r.Primary.Attributes["user_id"], r.Primary.ID); err == nil {
 			return fmt.Errorf("User contact method still exists")
 		}
 
@@ -121,14 +119,12 @@ func testAccCheckPagerDutyUserContactMethodExists(n string) resource.TestCheckFu
 
 		client := testAccProvider.Meta().(*pagerduty.Client)
 
-		userID, cmID := resourcePagerDutyUserContactMethodParseID(rs.Primary.ID)
-
-		found, _, err := client.Users.GetContactMethod(userID, cmID)
+		found, _, err := client.Users.GetContactMethod(rs.Primary.Attributes["user_id"], rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		if found.ID != cmID {
+		if found.ID != rs.Primary.ID {
 			return fmt.Errorf("Contact method not found: %v - %v", rs.Primary.ID, found)
 		}
 

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -1,0 +1,261 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func TestAccPagerDutyUserContactMethodEmail_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodEmailConfig(username, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserContactMethodEmailConfigUpdated(usernameUpdated, emailUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyUserContactMethodPhone_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodPhoneConfig(username, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserContactMethodPhoneConfigUpdated(usernameUpdated, emailUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyUserContactMethodSMS_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodSMSConfig(username, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserContactMethodSMSConfigUpdated(usernameUpdated, emailUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyUserContactMethodDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_user_contact_method" {
+			continue
+		}
+
+		userID, cmID := resourcePagerDutyUserContactMethodParseID(r.Primary.ID)
+
+		if _, _, err := client.Users.GetContactMethod(userID, cmID); err == nil {
+			return fmt.Errorf("User contact method still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyUserContactMethodExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user contact method ID is set")
+		}
+
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		userID, cmID := resourcePagerDutyUserContactMethodParseID(rs.Primary.ID)
+
+		found, _, err := client.Users.GetContactMethod(userID, cmID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != cmID {
+			return fmt.Errorf("Contact method not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyUserContactMethodEmailConfig(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  type    = "email_contact_method"
+  address = "%[1]v%[2]v"
+  label   = "%[1]v"
+}
+`, username, email)
+}
+
+func testAccCheckPagerDutyUserContactMethodEmailConfigUpdated(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  type    = "email_contact_method"
+  address = "%[1]v%[2]v"
+  label   = "%[1]v"
+}
+`, username, email)
+}
+
+func testAccCheckPagerDutyUserContactMethodPhoneConfig(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id      = "${pagerduty_user.foo.id}"
+  type         = "phone_contact_method"
+  country_code = "+1"
+  address      = "2025550199"
+  label        = "%[1]v"
+}
+`, username, email)
+}
+
+func testAccCheckPagerDutyUserContactMethodPhoneConfigUpdated(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id      = "${pagerduty_user.foo.id}"
+  type         = "phone_contact_method"
+  country_code = "+1"
+  address      = "2025550104"
+  label        = "%[1]v"
+}
+`, username, email)
+}
+
+func testAccCheckPagerDutyUserContactMethodSMSConfig(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id      = "${pagerduty_user.foo.id}"
+  type         = "sms_contact_method"
+  country_code = "+1"
+  address      = "2025550199"
+  label        = "%[1]v"
+}
+`, username, email)
+}
+
+func testAccCheckPagerDutyUserContactMethodSMSConfigUpdated(username, email string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[2]v"
+  color       = "red"
+  role        = "user"
+  job_title   = "bar"
+  description = "bar"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id      = "${pagerduty_user.foo.id}"
+  type         = "sms_contact_method"
+  country_code = "+1"
+  address      = "2025550104"
+  label        = "%[1]v"
+}
+`, username, email)
+}

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_user_contact_method"
+sidebar_current: "docs-pagerduty-resource-user-contact-method"
+description: |-
+  Creates and manages contact methods for a user in PagerDuty.
+---
+
+# pagerduty_user_contact_method
+
+A [contact method](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Users/get_users_id_contact_methods) is a contact method for a PagerDuty user (email, phone or SMS).
+
+
+## Example Usage
+
+```hcl
+resource "pagerduty_user" "example" {
+  name  = "Earline Greenholt"
+  email = "125.greenholt.earline@graham.name"
+  teams = ["${pagerduty_team.example.id}"]
+}
+
+resource "pagerduty_user_contact_method" "email" {
+  user_id = "${pagerduty_user.example.id}"
+  type    = "email_contact_method"
+  address = "foo@bar.com"
+  label   = "Work"
+}
+
+resource "pagerduty_user_contact_method" "phone" {
+  user_id      = "${pagerduty_user.example.id}"
+  type         = "phone_contact_method"
+  country_code = "+1"
+  address      = "2025550199"
+  label        = "Work"
+}
+
+resource "pagerduty_user_contact_method" "sms" {
+  user_id      = "${pagerduty_user.example.id}"
+  type         = "sms_contact_method"
+  country_code = "+1"
+  address      = "2025550199"
+  label        = "Work"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `user_id` - (Required) The ID of the user.
+  * `type` - (Required) The contact method type. May be (`email_contact_method`, `phone_contact_method`, `sms_contact_method`).
+  * `send_short_email` - (Optional) Send an abbreviated email message instead of the standard email output.
+  * `country_code` - (Optional) The 1-to-3 digit country calling code. Required when using `phone_contact_method` or `sms_contact_method`.
+  * `label` - (Required) The label (e.g., "Work", "Mobile", etc.).
+  * `address` - (Required) The "address" to deliver to: `email`, `phone number`, etc., depending on the type.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the user and contact method in the format of (<userID>:<contactMethodID>)
+  * `contact_method_id` - The ID of the contact method.
+  * `blacklisted` - If true, this phone has been blacklisted by PagerDuty and no messages will be sent to it.
+  * `enabled` - If true, this phone is capable of receiving SMS messages.
+
+## Import
+
+Contact methods can be imported using the `user_id` and the `id`, e.g.
+
+```
+$ terraform import pagerduty_user_contact_method.main PLBP09X:PLBP09X
+```

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -59,8 +59,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-  * `id` - The ID of the user and contact method in the format of (<userID>:<contactMethodID>)
-  * `contact_method_id` - The ID of the contact method.
+  * `id` - The ID of the contact method.
   * `blacklisted` - If true, this phone has been blacklisted by PagerDuty and no messages will be sent to it.
   * `enabled` - If true, this phone is capable of receiving SMS messages.
 

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -58,6 +58,9 @@
                 <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
                     <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-user-contact-method") %>>
+                    <a href="/docs/providers/pagerduty/r/user_contact_method.html">pagerduty_user_contact_method</a>
+                </li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
This PR continues the work in #2 and aims to add support for contact methods in PagerDuty.
The currently supported contact methods are: `email`, `phone` & `sms`. 
Push notifications may come in a second pass.