### PR TITLE
provider: handle not found errors better

### DIFF
--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -3,7 +3,6 @@ package pagerduty
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -19,6 +18,7 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  false,
 			},
+
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -50,7 +50,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData) error {
-	if perr, ok := err.(*pagerduty.Error); ok && strings.Contains(perr.Message, "Not Found") {
+	if perr, ok := err.(*pagerduty.Error); ok && perr.ErrorResponse.StatusCode == 404 {
 		log.Printf("[WARN] Removing %s because it's gone", d.Id())
 		d.SetId("")
 		return nil

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -49,7 +50,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData) error {
-	if perr, ok := err.(*pagerduty.Error); ok && perr.Code == 2100 {
+	if perr, ok := err.(*pagerduty.Error); ok && strings.Contains(perr.Message, "Not Found") {
 		log.Printf("[WARN] Removing %s because it's gone", d.Id())
 		d.SetId("")
 		return nil

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -169,7 +169,7 @@ func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) err
 
 	schedule, _, err := client.Schedules.Get(d.Id(), &pagerduty.GetScheduleOptions{})
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	d.Set("name", schedule.Name)


### PR DESCRIPTION
This should handle most, if not all resource not found errors returned by the PagerDuty API (https://v2.developer.pagerduty.com/docs/errors#pagerduty-error-codes).