### PR TITLE
testing: add necessary dependencies to sweeper configurations

### DIFF
--- a/pagerduty/resource_pagerduty_addon_test.go
+++ b/pagerduty/resource_pagerduty_addon_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_addon", &resource.Sweeper{
+		Name: "pagerduty_addon",
+		F:    testSweepAddon,
+	})
+}
+
 func testSweepAddon(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_escalation_policy", &resource.Sweeper{
+		Name: "pagerduty_escalation_policy",
+		F:    testSweepEscalationPolicy,
+		Dependencies: []string{
+			"pagerduty_team",
+			"pagerduty_user",
+		},
+	})
+}
+
 func testSweepEscalationPolicy(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_schedule", &resource.Sweeper{
+		Name:         "pagerduty_schedule",
+		F:            testSweepSchedule,
+		Dependencies: []string{"pagerduty_user"},
+	})
+}
+
 func testSweepSchedule(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_service", &resource.Sweeper{
+		Name: "pagerduty_service",
+		F:    testSweepService,
+		Dependencies: []string{
+			"pagerduty_escalation_policy",
+			"pagerduty_user",
+		},
+	})
+}
+
 func testSweepService(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_team", &resource.Sweeper{
+		Name: "pagerduty_team",
+		F:    testSweepTeam,
+	})
+}
+
 func testSweepTeam(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+func init() {
+	resource.AddTestSweepers("pagerduty_user", &resource.Sweeper{
+		Name:         "pagerduty_user",
+		F:            testSweepUser,
+		Dependencies: []string{"pagerduty_team"},
+	})
+}
+
 func testSweepUser(region string) error {
 	config, err := sharedConfigForRegion(region)
 	if err != nil {

--- a/pagerduty/sweeper_test.go
+++ b/pagerduty/sweeper_test.go
@@ -8,38 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func init() {
-	resource.AddTestSweepers("pagerduty_service", &resource.Sweeper{
-		Name: "pagerduty_service",
-		F:    testSweepService,
-	})
-
-	resource.AddTestSweepers("pagerduty_escalation_policy", &resource.Sweeper{
-		Name: "pagerduty_escalation_policy",
-		F:    testSweepEscalationPolicy,
-	})
-
-	resource.AddTestSweepers("pagerduty_user", &resource.Sweeper{
-		Name: "pagerduty_user",
-		F:    testSweepUser,
-	})
-
-	resource.AddTestSweepers("pagerduty_team", &resource.Sweeper{
-		Name: "pagerduty_team",
-		F:    testSweepTeam,
-	})
-
-	resource.AddTestSweepers("pagerduty_schedule", &resource.Sweeper{
-		Name: "pagerduty_schedule",
-		F:    testSweepSchedule,
-	})
-
-	resource.AddTestSweepers("pagerduty_addon", &resource.Sweeper{
-		Name: "pagerduty_addon",
-		F:    testSweepAddon,
-	})
-}
-
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }


### PR DESCRIPTION
This PR adds the necessary dependencies to the sweeper configurations to prevent potential errors while sweeping.