### PR TITLE
r/pagerduty_schedule: Don't read back `start` value for schedule layers.

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -176,6 +176,19 @@ func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("time_zone", schedule.TimeZone)
 	d.Set("description", schedule.Description)
 
+	// Here we override whatever `start` value we get back from the API
+	// and use what's in the configuration. This is to prevent a diff issue
+	// because we always get back a new `start` value from the PagerDuty API.
+	for _, sl := range schedule.ScheduleLayers {
+		for _, rsl := range d.Get("layer").([]interface{}) {
+			ssl := rsl.(map[string]interface{})
+
+			if sl.ID == ssl["id"].(string) {
+				sl.Start = ssl["start"].(string)
+			}
+		}
+	}
+
 	if err := d.Set("layer", flattenScheduleLayers(schedule.ScheduleLayers)); err != nil {
 		return err
 	}

--- a/website/docs/r/schedule.html.markdown
+++ b/website/docs/r/schedule.html.markdown
@@ -56,7 +56,7 @@ If you do pass the `overflow` parameter, you will get one schedule entry returne
 Schedule layers (`layer`) supports the following:
 
 * `name` - (Optional) The name of the schedule layer.
-* `start` - (Required) The start time of the schedule layer.
+* `start` - (Required) The start time of the schedule layer. This value will not be read back from the PagerDuty API because the API will always return a new `start` time, which represents the last updated time of the schedule layer.
 * `end` - (Optional) The end time of the schedule layer. If not specified, the layer does not end.
 * `rotation_virtual_start` - (Required) The effective start time of the schedule layer. This can be before the start time of the schedule.
 * `rotation_turn_length_seconds` - (Required) The duration of each on-call shift in `seconds`.


### PR DESCRIPTION
This PR fixes a bug found in `pagerduty_schedule` (described in #34) related to `start`.

The PagerDuty API always returns a new `start` value, 
which in turn causes Terraform to get a diff on every plan. 

This PR should resolve that, by ignoring whatever value we get back from the API.
