### PR TITLE
r/pagerduty_service: add alert_creation attribute

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -26,6 +26,15 @@ func resourcePagerDutyService() *schema.Resource {
 				Optional: true,
 				Default:  "Managed by Terraform",
 			},
+			"alert_creation": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "create_incidents",
+				ValidateFunc: validateValueFunc([]string{
+					"create_alerts_and_incidents",
+					"create_incidents",
+				}),
+			},
 			"auto_resolve_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -191,6 +200,10 @@ func buildServiceStruct(d *schema.ResourceData) *pagerduty.Service {
 		service.AcknowledgementTimeout = attr.(int)
 	}
 
+	if attr, ok := d.GetOk("alert_creation"); ok {
+		service.AlertCreation = attr.(string)
+	}
+
 	if attr, ok := d.GetOk("escalation_policy"); ok {
 		service.EscalationPolicy = &pagerduty.EscalationPolicyReference{
 			ID:   attr.(string),
@@ -248,6 +261,7 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("auto_resolve_timeout", service.AutoResolveTimeout)
 	d.Set("last_incident_timestamp", service.LastIncidentTimestamp)
 	d.Set("acknowledgement_timeout", service.AcknowledgementTimeout)
+	d.Set("alert_creation", service.AlertCreation)
 
 	if service.IncidentUrgencyRule != nil {
 		if err := d.Set("incident_urgency_rule", flattenIncidentUrgencyRule(service.IncidentUrgencyRule)); err != nil {

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -65,6 +65,8 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
 					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
+					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
@@ -84,6 +86,8 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -120,6 +124,8 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -182,6 +188,8 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -261,6 +269,8 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
 					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
+					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
@@ -280,6 +290,8 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -39,6 +39,7 @@ resource "pagerduty_service" "example" {
   auto_resolve_timeout    = 14400
   acknowledgement_timeout = 600
   escalation_policy       = "${pagerduty_escalation_policy.example.id}"
+  alert_creation          = "create_incidents"
 }
 ```
 
@@ -52,6 +53,7 @@ The following arguments are supported:
   * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long. Disabled if not set.
   * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged. Disabled if not set.
   * `escalation_policy` - (Required) The escalation policy used by this service.
+  * `alert_creation` - (Optional) Must be one of two values. PagerDuty receives events from your monitoring systems and can then create incidents in different ways. Value "create_incidents" is default: events will create an incident that cannot be merged. Value "create_alerts_and_incidents" is the alternative: events will create an alert and then add it to a new incident, these incidents can be merged.
 
 You may specify one optional `incident_urgency_rule` block configuring what urgencies to use.
 Your PagerDuty account must have the `urgencies` ability to assign an incident urgency rule.


### PR DESCRIPTION
This PR adds the `alert_creation` attribute documented [here](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/put_services_id) to the pagerduty service resource.

Acc test are passing for me, documentation has been added.