### PR TITLE
r/pagerduty_schedule: Allow layer updates

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
@@ -41,7 +42,6 @@ func resourcePagerDutySchedule() *schema.Resource {
 			"layer": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -186,10 +186,16 @@ func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) err
 			if sl.ID == ssl["id"].(string) {
 				sl.Start = ssl["start"].(string)
 			}
+
 		}
 	}
 
-	if err := d.Set("layer", flattenScheduleLayers(schedule.ScheduleLayers)); err != nil {
+	layers, err := flattenScheduleLayers(schedule.ScheduleLayers)
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("layer", layers); err != nil {
 		return err
 	}
 
@@ -204,15 +210,50 @@ func resourcePagerDutyScheduleUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	o := &pagerduty.UpdateScheduleOptions{}
+	opts := &pagerduty.UpdateScheduleOptions{}
 
 	if v, ok := d.GetOk("overflow"); ok {
-		o.Overflow = v.(bool)
+		opts.Overflow = v.(bool)
+	}
+
+	// A schedule layer can never be removed but it can be ended.
+	// Here we determine which layer has been removed from the configuration
+	// and we mark it as ended. This is to avoid diff issues.
+	if d.HasChange("layer") {
+		oraw, nraw := d.GetChange("layer")
+
+		osl, err := expandScheduleLayers(oraw.([]interface{}))
+		if err != nil {
+			return err
+		}
+
+		nsl, err := expandScheduleLayers(nraw.([]interface{}))
+		if err != nil {
+			return err
+		}
+
+		for _, o := range osl {
+			found := false
+			for _, n := range nsl {
+				if o.ID == n.ID {
+					found = true
+				}
+			}
+
+			if !found {
+				end, err := timeToUTC(time.Now().Format(time.RFC3339))
+				if err != nil {
+					return err
+				}
+				o.End = end.String()
+				schedule.ScheduleLayers = append(schedule.ScheduleLayers, o)
+			}
+		}
 	}
 
 	log.Printf("[INFO] Updating PagerDuty schedule: %s", d.Id())
 
-	if _, _, err := client.Schedules.Update(d.Id(), schedule, o); err != nil {
+	if _, _, err := client.Schedules.Update(d.Id(), schedule, opts); err != nil {
 		return err
 	}
 
@@ -255,7 +296,7 @@ func expandScheduleLayers(v interface{}) ([]*pagerduty.ScheduleLayer, error) {
 			Name:                      rsl["name"].(string),
 			Start:                     rsl["start"].(string),
 			End:                       rsl["end"].(string),
-			RotationVirtualStart:      rvs,
+			RotationVirtualStart:      rvs.String(),
 			RotationTurnLengthSeconds: rsl["rotation_turn_length_seconds"].(int),
 		}
 
@@ -288,10 +329,24 @@ func expandScheduleLayers(v interface{}) ([]*pagerduty.ScheduleLayer, error) {
 	return scheduleLayers, nil
 }
 
-func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) []map[string]interface{} {
+func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) ([]map[string]interface{}, error) {
 	var scheduleLayers []map[string]interface{}
 
 	for _, sl := range v {
+		// A schedule layer can never be removed but it can be ended.
+		// Here we check each layer and if it has been ended we don't read it back
+		// because it's not relevant anymore.
+		if sl.End != "" {
+			end, err := timeToUTC(sl.End)
+			if err != nil {
+				return nil, err
+			}
+
+			if time.Now().UTC().After(end) {
+				continue
+			}
+		}
+
 		scheduleLayer := map[string]interface{}{
 			"id":                           sl.ID,
 			"name":                         sl.Name,
@@ -337,5 +392,5 @@ func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) []map[string]interface{
 		resultReversed = append(resultReversed, scheduleLayers[i])
 	}
 
-	return resultReversed
+	return resultReversed, nil
 }

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -74,13 +74,19 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "time_zone", location),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "layer.#", "1"),
+						"pagerduty_schedule.foo", "layer.#", "2"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.start", start),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.name", "bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.start", start),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
 			{
@@ -328,20 +334,34 @@ func testAccCheckPagerDutyScheduleExists(n string) resource.TestCheckFunc {
 func testAccCheckPagerDutyScheduleConfig(username, email, schedule, location, start, rotationVirtualStart string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name  = "%s"
-  email = "%s"
+  name  = "%[1]v"
+  email = "%[2]v"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "%s"
+  name = "%[3]v"
 
-  time_zone   = "%s"
+  time_zone   = "%[4]v"
   description = "foo"
 
   layer {
     name                         = "foo"
-    start                        = "%s"
-    rotation_virtual_start       = "%s"
+    start                        = "%[5]v"
+    rotation_virtual_start       = "%[6]v"
+    rotation_turn_length_seconds = 86400
+    users                        = ["${pagerduty_user.foo.id}"]
+
+    restriction {
+      type              = "daily_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 32101
+    }
+  }
+
+  layer {
+    name                         = "bar"
+    start                        = "%[5]v"
+    rotation_virtual_start       = "%[6]v"
     rotation_turn_length_seconds = 86400
     users                        = ["${pagerduty_user.foo.id}"]
 

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -7,13 +7,13 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func timeToUTC(v string) (string, error) {
+func timeToUTC(v string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, v)
 	if err != nil {
-		return "", err
+		return time.Time{}, err
 	}
 
-	return t.UTC().String(), nil
+	return t.UTC(), nil
 }
 
 // validateRFC3339 validates that a date string has the correct RFC3339 layout


### PR DESCRIPTION
This PR adds support for updating layers, thus removing the need for `ForceNew`.

A layer can never be removed but it can be set to end at a specific time. 
With this PR we can tag layers that have been deleted from the configuration as ended
and later when we read back the schedule layers we do a check whether a layer has been ended or not.

This should partially resolve #43.