### PR TITLE
Fix service integration importation when more than 100 services exist

### DIFF
--- a/pagerduty/import_pagerduty_service_integration_test.go
+++ b/pagerduty/import_pagerduty_service_integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
@@ -26,9 +27,14 @@ func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
 
 			{
 				ResourceName:      "pagerduty_service_integration.foo",
+				ImportStateIdFunc: testAccCheckPagerDutyServiceIntegrationId,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccCheckPagerDutyServiceIntegrationId(s *terraform.State) (string, error) {
+	return fmt.Sprintf("%v.%v", s.RootModule().Resources["pagerduty_service.foo"].Primary.ID, s.RootModule().Resources["pagerduty_service_integration.foo"].Primary.ID), nil
 }

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -24,7 +24,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 			},
 			"service": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"type": {
 				Type:          schema.TypeString,

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -1,11 +1,12 @@
 package pagerduty
 
 import (
-	"fmt"
 	"log"
 
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
+	"strings"
 )
 
 func resourcePagerDutyServiceIntegration() *schema.Resource {
@@ -188,26 +189,20 @@ func resourcePagerDutyServiceIntegrationDelete(d *schema.ResourceData, meta inte
 func resourcePagerDutyServiceIntegrationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*pagerduty.Client)
 
-	resp, _, err := client.Services.List(&pagerduty.ListServicesOptions{Limit: 100})
+	ids := strings.Split(d.Id(), ".")
+
+	if len(ids) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_service_integration. Expecting an importation ID formed as '<service_id>.<integration_id>'")
+	}
+	sid, id := ids[0], ids[1]
+
+	_, _, err := client.Services.GetIntegration(sid, id, nil)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
 
-	var serviceID string
-
-	for _, service := range resp.Services {
-		for _, integration := range service.Integrations {
-			if integration.ID == d.Id() {
-				serviceID = service.ID
-			}
-		}
-	}
-
-	if serviceID == "" {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_service_integration. Could not locate a service ID for the integration")
-	}
-
-	d.Set("service", serviceID)
+	d.SetId(id)
+	d.Set("service", sid)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
@@ -16,15 +16,24 @@ func testStepImportState(
 	state *terraform.State,
 	step TestStep) (*terraform.State, error) {
 	// Determine the ID to import
-	importId := step.ImportStateId
-	if importId == "" {
+	var importId string
+	switch {
+	case step.ImportStateIdFunc != nil:
+		var err error
+		importId, err = step.ImportStateIdFunc(state)
+		if err != nil {
+			return state, err
+		}
+	case step.ImportStateId != "":
+		importId = step.ImportStateId
+	default:
 		resource, err := testResource(step, state)
 		if err != nil {
 			return state, err
 		}
-
 		importId = resource.Primary.ID
 	}
+
 	importPrefix := step.ImportStateIdPrefix
 	if importPrefix != "" {
 		importId = fmt.Sprintf("%s%s", importPrefix, importId)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -462,10 +462,10 @@
 			"versionExact": "v0.10.0"
 		},
 		{
-			"checksumSHA1": "dhU2woQaSEI2OnbYLdkHxf7/nu8=",
+			"checksumSHA1": "CwIwANN1kyCaXfotQ3YU0NxQ+xE=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
+			"revision": "8ba8fc79c106dee098c625f4c40cd53d73660a92",
+			"revisionTime": "2017-10-02T18:46:49Z",
 			"version": "v0.10.0",
 			"versionExact": "v0.10.0"
 		},

--- a/website/docs/r/service_integration.html.markdown
+++ b/website/docs/r/service_integration.html.markdown
@@ -99,3 +99,11 @@ The following attributes are exported:
   * `id` - The ID of the service integration.
   * `integration_key` - This is the unique key used to route events to this integration when received via the PagerDuty Events API.
   * `integration_email` - This is the unique fully-qualified email address used for routing emails to this integration for processing.
+
+## Import
+
+Services can be imported using their related `service` id and service integration `id` separated by a dot, e.g.
+
+```
+$ terraform import pagerduty_service.main PLSSSSS.PLIIIII
+```

--- a/website/docs/r/service_integration.html.markdown
+++ b/website/docs/r/service_integration.html.markdown
@@ -71,6 +71,7 @@ resource "pagerduty_service_integration" "cloudwatch" {
 
 The following arguments are supported:
 
+  * `service` - (Required) The ID of the service the integration should belong to.
   * `name` - (Optional) The name of the service integration.
   * `type` - (Optional) The service type. Can be:
   `aws_cloudwatch_inbound_integration`,
@@ -86,7 +87,6 @@ The following arguments are supported:
     **Note:** This is meant for **generic** service integrations.
     To integrate with a **vendor** (e.g Datadog or Amazon Cloudwatch) use the `vendor` field instead.
 
-  * `service` - (Optional) The ID of the service the integration should belong to.
   * `vendor` - (Optional) The ID of the vendor the integration should integrate with (e.g Datadog or Amazon Cloudwatch).
   * `integration_key` - (Optional) This is the unique key used to route events to this integration when received via the PagerDuty Events API.
   * `integration_email` - (Optional) This is the unique fully-qualified email address used for routing emails to this integration for processing.


### PR DESCRIPTION
Service integration importation failed with more than 100 services because the existing logic looped over the first hundred service to find a match.

Changing the importation logic to use an ID formed as `service_id.integration_id` resolves the issue.

This required updating the `github.com/hashicorp/terraform/helper/resource` dependency to v0.10.7 to get `ImportStateIdFunc` feature.