### PR TITLE
Add HTTP transport debugging using terraform's helper

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"runtime"
 
 	"github.com/hashicorp/terraform/helper/logging"
@@ -33,10 +34,15 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 		return nil, fmt.Errorf(invalidCreds)
 	}
 
+	var httpClient *http.Client
+	httpClient = http.DefaultClient
+	httpClient.Transport = logging.NewTransport("PagerDuty", http.DefaultTransport)
+
 	config := &pagerduty.Config{
-		Debug:     logging.IsDebugOrHigher(),
-		Token:     c.Token,
-		UserAgent: fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraform.VersionString()),
+		Debug:      logging.IsDebugOrHigher(),
+		HTTPClient: httpClient,
+		Token:      c.Token,
+		UserAgent:  fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraform.VersionString()),
 	}
 
 	client, err := pagerduty.NewClient(config)


### PR DESCRIPTION
This PR allows to log the body of HTTP requests and responses made to PagerDuty API when the `TF_LOG` environment variable is set to `debug`.

It is using the terraform transport logging helper from https://github.com/hashicorp/terraform/pull/14281.

There is one caveat though, only the first chunk of chunked responses gets logged:

```
pagerduty_service.bh[8]: Refreshing state... (ID: PXXXXXX)
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 2017/11/08 03:42:49 [INFO] Reading PagerDuty service PXXXXXX
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 2017/11/08 03:42:49 [DEBUG] PagerDuty - Preparing GET request to /services/PXXXXXX with body: %!s(<nil>)
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 2017/11/08 03:42:49 [DEBUG] PagerDuty API Request Details:
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: ---[ REQUEST ]---------------------------------------
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: GET /services/PXXXXXX HTTP/1.1
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Host: api.pagerduty.com
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: User-Agent: (linux amd64) Terraform/0.10.0-dev
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Accept: application/vnd.pagerduty+json;version=2
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Authorization: Token token=**************
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Content-Type: application/json
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Accept-Encoding: gzip
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99:
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99:
2017-11-08T03:42:49.331+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: -----------------------------------------------------
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 2017/11/08 03:42:49 [DEBUG] PagerDuty API Response Details:
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: ---[ RESPONSE ]--------------------------------------
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: HTTP/1.1 200 OK
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Transfer-Encoding: chunked
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Access-Control-Allow-Headers: Authorization, Content-Type
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Access-Control-Allow-Origin: *
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Access-Control-Max-Age: 1728000
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Cache-Control: max-age=0, private, must-revalidate
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Connection: keep-alive
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Content-Type: application/json; charset=utf-8
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Date: Wed, 08 Nov 2017 02:42:49 GMT
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Etag: W/"**************"
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Server: nginx
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: Status: 200 OK
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: X-Request-Id: **************
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: X-Ua-Compatible: IE=Edge,chrome=1
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99:
2017-11-08T03:42:49.668+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 889
2017-11-08T03:42:49.669+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: 0
2017-11-08T03:42:49.669+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99:
2017-11-08T03:42:49.669+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99:
2017-11-08T03:42:49.669+0100 [DEBUG] plugin.terraform-provider-pagerduty_v0.1.99: -----------------------------------------------------
```

This is invaluable to diagnose strange behaviors.