### PR TITLE
Allow disabling service incident timeouts (take 2)

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -39,6 +39,7 @@ func resourcePagerDutyService() *schema.Resource {
 			"auto_resolve_timeout": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "14400",
 			},
 			"last_incident_timestamp": {
 				Type:     schema.TypeString,
@@ -55,6 +56,7 @@ func resourcePagerDutyService() *schema.Resource {
 			"acknowledgement_timeout": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "1800",
 			},
 			"escalation_policy": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
@@ -36,7 +37,7 @@ func resourcePagerDutyService() *schema.Resource {
 				}),
 			},
 			"auto_resolve_timeout": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"last_incident_timestamp": {
@@ -52,7 +53,7 @@ func resourcePagerDutyService() *schema.Resource {
 				Computed: true,
 			},
 			"acknowledgement_timeout": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"escalation_policy": {
@@ -182,7 +183,7 @@ func resourcePagerDutyService() *schema.Resource {
 	}
 }
 
-func buildServiceStruct(d *schema.ResourceData) *pagerduty.Service {
+func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 	service := pagerduty.Service{
 		Name:   d.Get("name").(string),
 		Status: d.Get("status").(string),
@@ -193,11 +194,23 @@ func buildServiceStruct(d *schema.ResourceData) *pagerduty.Service {
 	}
 
 	if attr, ok := d.GetOk("auto_resolve_timeout"); ok {
-		service.AutoResolveTimeout = attr.(int)
+		if attr.(string) != "null" {
+			if val, err := strconv.Atoi(attr.(string)); err == nil {
+				service.AutoResolveTimeout = &val
+			} else {
+				return nil, err
+			}
+		}
 	}
 
 	if attr, ok := d.GetOk("acknowledgement_timeout"); ok {
-		service.AcknowledgementTimeout = attr.(int)
+		if attr.(string) != "null" {
+			if val, err := strconv.Atoi(attr.(string)); err == nil {
+				service.AcknowledgementTimeout = &val
+			} else {
+				return nil, err
+			}
+		}
 	}
 
 	if attr, ok := d.GetOk("alert_creation"); ok {
@@ -223,17 +236,20 @@ func buildServiceStruct(d *schema.ResourceData) *pagerduty.Service {
 		service.ScheduledActions = expandScheduledActions(attr)
 	}
 
-	return &service
+	return &service, nil
 }
 
 func resourcePagerDutyServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pagerduty.Client)
 
-	service := buildServiceStruct(d)
+	service, err := buildServiceStruct(d)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Creating PagerDuty service %s", service.Name)
 
-	service, _, err := client.Services.Create(service)
+	service, _, err = client.Services.Create(service)
 	if err != nil {
 		return err
 	}
@@ -258,9 +274,17 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("created_at", service.CreatedAt)
 	d.Set("escalation_policy", service.EscalationPolicy.ID)
 	d.Set("description", service.Description)
-	d.Set("auto_resolve_timeout", service.AutoResolveTimeout)
+	if service.AutoResolveTimeout == nil {
+		d.Set("auto_resolve_timeout", "null")
+	} else {
+		d.Set("auto_resolve_timeout", strconv.Itoa(*service.AutoResolveTimeout))
+	}
 	d.Set("last_incident_timestamp", service.LastIncidentTimestamp)
-	d.Set("acknowledgement_timeout", service.AcknowledgementTimeout)
+	if service.AcknowledgementTimeout == nil {
+		d.Set("acknowledgement_timeout", "null")
+	} else {
+		d.Set("acknowledgement_timeout", strconv.Itoa(*service.AcknowledgementTimeout))
+	}
 	d.Set("alert_creation", service.AlertCreation)
 
 	if service.IncidentUrgencyRule != nil {
@@ -287,7 +311,10 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 func resourcePagerDutyServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pagerduty.Client)
 
-	service := buildServiceStruct(d)
+	service, err := buildServiceStruct(d)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Updating PagerDuty service %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -116,9 +116,9 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_resolve_timeout", "0"),
+						"pagerduty_service.foo", "auto_resolve_timeout", "null"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "acknowledgement_timeout", "0"),
+						"pagerduty_service.foo", "acknowledgement_timeout", "null"),
 				),
 			},
 		},
@@ -518,8 +518,8 @@ resource "pagerduty_escalation_policy" "foo" {
 resource "pagerduty_service" "foo" {
 	name                    = "%s"
 	description             = "bar"
-	auto_resolve_timeout    = 0
-	acknowledgement_timeout = 0
+	auto_resolve_timeout    = "null"
+	acknowledgement_timeout = "null"
 
 	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
 	incident_urgency_rule {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -60,10 +60,10 @@ type Integration struct {
 
 // Service represents a service.
 type Service struct {
-	AcknowledgementTimeout int                        `json:"acknowledgement_timeout"`
+	AcknowledgementTimeout *int                       `json:"acknowledgement_timeout"`
 	Addons                 []*AddonReference          `json:"addons,omitempty"`
 	AlertCreation          string                     `json:"alert_creation,omitempty"`
-	AutoResolveTimeout     int                        `json:"auto_resolve_timeout"`
+	AutoResolveTimeout     *int                       `json:"auto_resolve_timeout"`
 	CreatedAt              string                     `json:"created_at,omitempty"`
 	Description            string                     `json:"description,omitempty"`
 	EscalationPolicy       *EscalationPolicyReference `json:"escalation_policy,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -522,10 +522,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "XFSyecgEgORKyxI8bfX8esMIBlE=",
+			"checksumSHA1": "ZQ0pchJreisfmNgJq387N9kqA+w=",
 			"path": "github.com/heimweh/go-pagerduty/pagerduty",
-			"revision": "4e8f8a6e375122d5ac801cd08bb0425ab2899549",
-			"revisionTime": "2017-10-20T17:28:17Z"
+			"revision": "64f5bd2f9c706f1b708fa7cc4e511611bc307890",
+			"revisionTime": "2017-11-24T16:45:11Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -50,8 +50,8 @@ The following arguments are supported:
   * `name` - (Required) The name of the service.
   * `description` - (Optional) A human-friendly description of the escalation policy.
     If not set, a placeholder of "Managed by Terraform" will be set.
-  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long. Disabled if not set.
-  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged. Disabled if not set.
+  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long. Disabled if set to the `"null"` string.
+  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged. Disabled if set to the `"null"` string.
   * `escalation_policy` - (Required) The escalation policy used by this service.
   * `alert_creation` - (Optional) Must be one of two values. PagerDuty receives events from your monitoring systems and can then create incidents in different ways. Value "create_incidents" is default: events will create an incident that cannot be merged. Value "create_alerts_and_incidents" is the alternative: events will create an alert and then add it to a new incident, these incidents can be merged.
 


### PR DESCRIPTION
Resolves #51 (and #41 for good).

Checklist:

- [x] add test case
- [x] implement fix
- [x] update documentation
- [x] update vendored go-pagerduty once upstream PR heimweh/go-pagerduty#20 is merged
- [x] remove [WIP] marker

# Rationale:

This PR changes `auto_resolve_timeout` and `acknowledgement_timeout` fields from `int` to `string` type to allow passing a "null" value which means disabled as documented at https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/post_services

My previous fix in #44 did not work as expected as 0 effectively means 0 second, resulting in incidents to be instantaneously marked as resolved.

To avoid backward incompatible changes to existing terraform configurations, I preserved the default API values of 4h for `auto_resolve_timeout` and 30 minutes for `acknowledgement_timeout`.
Note that those are not explicitely stated in the v2 API documentation so I got them from the API v1: https://v1.developer.pagerduty.com/documentation/rest/services/create

I'm preparing a PR for go-pagerduty to remove the local vendor patch.

# Acceptance tests results:

```
make testacc TEST=./pagerduty/ TESTARGS='-run=TestAccPagerDutyService_.*'                                         
==> Checking that code complies with gofmt requirements...                                   
TF_ACC=1 go test ./pagerduty/ -v -run=TestAccPagerDutyService_.* -timeout 120m               
=== RUN   TestAccPagerDutyService_import      
--- PASS: TestAccPagerDutyService_import (11.78s)
=== RUN   TestAccPagerDutyService_Basic
--- PASS: TestAccPagerDutyService_Basic (21.37s)
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (15.78s)
=== RUN   TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules (17.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   66.371s
```