### PR TITLE
d/pagerduty_vendor: Match whole string and fallback to partial matching

### DIFF
--- a/pagerduty/data_source_pagerduty_vendor.go
+++ b/pagerduty/data_source_pagerduty_vendor.go
@@ -49,12 +49,23 @@ func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) err
 
 	var found *pagerduty.Vendor
 
-	r := regexp.MustCompile("(?i)" + searchName)
+	er := regexp.MustCompile(fmt.Sprintf("^(?i)%s$", searchName))
 
 	for _, vendor := range resp.Vendors {
-		if r.MatchString(vendor.Name) {
+		if er.MatchString(vendor.Name) {
 			found = vendor
 			break
+		}
+	}
+
+	// We didn't find an exact match, so let's fallback to partial matching.
+	if found == nil {
+		pr := regexp.MustCompile("(?i)" + searchName)
+		for _, vendor := range resp.Vendors {
+			if pr.MatchString(vendor.Name) {
+				found = vendor
+				break
+			}
 		}
 	}
 

--- a/pagerduty/data_source_pagerduty_vendor_test.go
+++ b/pagerduty/data_source_pagerduty_vendor_test.go
@@ -1,14 +1,13 @@
 package pagerduty
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourcePagerDutyVendor_Basic(t *testing.T) {
+	dataSourceName := "data.pagerduty_vendor.foo"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -17,41 +16,40 @@ func TestAccDataSourcePagerDutyVendor_Basic(t *testing.T) {
 			{
 				Config: testAccDataSourcePagerDutyVendorConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourcePagerDutyVendor("data.pagerduty_vendor.foo"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", "PZQ6AUS"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "Amazon Cloudwatch"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourcePagerDutyVendor(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		r := s.RootModule().Resources[n]
-		a := r.Primary.Attributes
-
-		if a["id"] == "" {
-			return fmt.Errorf("Expected to get a vendor ID from PagerDuty")
-		}
-
-		if a["id"] != "PZQ6AUS" {
-			return fmt.Errorf("Expected the Datadog Vendor ID to be: PZQ6AUS, but got: %s", a["id"])
-		}
-
-		if a["name"] != "Amazon Cloudwatch" {
-			return fmt.Errorf("Expected the Datadog Vendor Name to be: Datadog, but got: %s", a["name"])
-		}
-
-		if a["type"] != "api" {
-			return fmt.Errorf("Expected the Datadog Vendor Type to be: api, but got: %s", a["type"])
-		}
-
-		return nil
-	}
+func TestAccDataSourcePagerDutyVendor_ExactMatch(t *testing.T) {
+	dataSourceName := "data.pagerduty_vendor.foo"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyExactMatchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "id", "PKG4M95"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "Sentry"),
+				),
+			},
+		},
+	})
 }
 
 const testAccDataSourcePagerDutyVendorConfig = `
 data "pagerduty_vendor" "foo" {
   name = "cloudwatch"
+}
+`
+
+const testAccDataSourcePagerDutyExactMatchConfig = `
+data "pagerduty_vendor" "foo" {
+  name = "sentry"
 }
 `


### PR DESCRIPTION
Fixes #54 

This PR solves an issue where a vendor search for: "Sentry" would return "IPSentry" instead of "Sentry". To fix this we match the whole string instead.