### PR TITLE
r/pagerduty_service: allow incident_urgency_rule to be computed

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -64,6 +64,7 @@ func resourcePagerDutyService() *schema.Resource {
 			},
 			"incident_urgency_rule": &schema.Schema{
 				Type:     schema.TypeList,
+				Computed: true,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -258,7 +259,7 @@ func resourcePagerDutyServiceCreate(d *schema.ResourceData, meta interface{}) er
 
 	d.SetId(service.ID)
 
-	return nil
+	return resourcePagerDutyServiceRead(d, meta)
 }
 
 func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) error {

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -442,10 +442,6 @@ resource "pagerduty_service" "foo" {
 	auto_resolve_timeout    = 1800
 	acknowledgement_timeout = 1800
 	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
-	incident_urgency_rule {
-		type    = "constant"
-		urgency = "high"
-	}
 }
 `, username, email, escalationPolicy, service)
 }


### PR DESCRIPTION
This resolves a diff issue described in #61, where a service created without an `incident_urgency_rule` block and causes a diff to be displayed on subsequent Terraform runs. 

Fixes #61 