### PR TITLE
Don't re-create services if support hours or scheduled actions change

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -120,7 +120,7 @@ func resourcePagerDutyService() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				MinItems: 1,
-				ForceNew: true,
+				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -151,7 +151,7 @@ func resourcePagerDutyService() *schema.Resource {
 			"scheduled_actions": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -371,47 +371,6 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 	})
 }
 
-func TestAccPagerDutyService_ScheduledActionsChange(t *testing.T) {
-	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
-	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	service_id := ""
-	p_service_id := &service_id
-	updated_service_id := ""
-	p_updated_service_id := &updated_service_id
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", service),
-					testAccCheckPagerDutyServiceSaveServiceId(p_service_id, "pagerduty_service.foo"),
-				),
-			},
-			{
-				Config: testAccCheckPagerDutyServiceWithScheduledActionsConfigUpdated(username, email, escalationPolicy, service),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", service),
-					testAccCheckPagerDutyServiceSaveServiceId(p_updated_service_id, "pagerduty_service.foo"),
-				),
-			},
-		},
-	})
-
-	if service_id != updated_service_id {
-		t.Error(fmt.Errorf("Expected service id to be %s, but found %s", service_id, updated_service_id))
-	}
-}
-
 func TestAccPagerDutyService_SupportHoursChange(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.com", username)
@@ -464,7 +423,18 @@ func testAccCheckPagerDutyServiceSaveServiceId(p *string, n string) resource.Tes
 			return fmt.Errorf("No Service ID is set")
 		}
 
-		*p = rs.Primary.ID
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		found, _, err := client.Services.Get(rs.Primary.ID, &pagerduty.GetServiceOptions{})
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Service not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		*p = found.ID
 
 		return nil
 	}
@@ -758,71 +728,6 @@ resource "pagerduty_service" "foo" {
 `, username, email, escalationPolicy, service)
 }
 
-func testAccCheckPagerDutyServiceWithScheduledActionsConfigUpdated(username, email, escalationPolicy, service string) string {
-	return fmt.Sprintf(`
-resource "pagerduty_user" "foo" {
-	name        = "%s"
-	email       = "%s"
-	color       = "green"
-	role        = "user"
-	job_title   = "foo"
-	description = "foo"
-}
-
-resource "pagerduty_escalation_policy" "foo" {
-	name        = "%s"
-	description = "bar"
-	num_loops   = 2
-
-	rule {
-		escalation_delay_in_minutes = 10
-		target {
-			type = "user_reference"
-			id   = "${pagerduty_user.foo.id}"
-		}
-	}
-}
-
-resource "pagerduty_service" "foo" {
-	name                    = "%s"
-	description             = "foo"
-	auto_resolve_timeout    = 1800
-	acknowledgement_timeout = 1800
-	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
-
-	incident_urgency_rule {
-		type = "use_support_hours"
-
-		during_support_hours {
-			type    = "constant"
-			urgency = "low"
-		}
-		outside_support_hours {
-			type    = "constant"
-			urgency = "high"
-		}
-	}
-
-	support_hours = [{
-		type         = "fixed_time_per_day"
-		time_zone    = "America/Lima"
-		start_time   = "09:00:00"
-		end_time     = "17:00:00"
-		days_of_week = [ 1, 2, 3, 4, 5 ]
-	}]
-
-	scheduled_actions {
-		type = "urgency_change"
-		to_urgency = "high"
-		at {
-			type = "named_time",
-			name = "support_hours_end"
-		}
-	}
-}
-`, username, email, escalationPolicy, service)
-}
-
 func testAccCheckPagerDutyServiceWithSupportHoursConfigUpdated(username, email, escalationPolicy, service string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -856,34 +761,10 @@ resource "pagerduty_service" "foo" {
 	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
 
 	incident_urgency_rule {
-		type = "use_support_hours"
-
-		during_support_hours {
-			type    = "constant"
-			urgency = "high"
-		}
-		outside_support_hours {
-			type    = "constant"
-			urgency = "low"
-		}
+		type = "constant"
+		urgency = "high"
 	}
 
-	support_hours = [{
-		type         = "fixed_time_per_day"
-		time_zone    = "America/Lima"
-		start_time   = "08:00:00"
-		end_time     = "18:00:00"
-		days_of_week = [ 1, 2, 3, 4 ]
-	}]
-
-	scheduled_actions {
-		type = "urgency_change"
-		to_urgency = "high"
-		at {
-			type = "named_time",
-			name = "support_hours_start"
-		}
-	}
 }
 `, username, email, escalationPolicy, service)
 }

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -371,6 +371,105 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 	})
 }
 
+func TestAccPagerDutyService_ScheduledActionsChange(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service_id := ""
+	p_service_id := &service_id
+	updated_service_id := ""
+	p_updated_service_id := &updated_service_id
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					testAccCheckPagerDutyServiceSaveServiceId(p_service_id, "pagerduty_service.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceWithScheduledActionsConfigUpdated(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					testAccCheckPagerDutyServiceSaveServiceId(p_updated_service_id, "pagerduty_service.foo"),
+				),
+			},
+		},
+	})
+
+	if service_id != updated_service_id {
+		t.Error(fmt.Errorf("Expected service id to be %s, but found %s", service_id, updated_service_id))
+	}
+}
+
+func TestAccPagerDutyService_SupportHoursChange(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service_id := ""
+	p_service_id := &service_id
+	updated_service_id := ""
+	p_updated_service_id := &updated_service_id
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					testAccCheckPagerDutyServiceSaveServiceId(p_service_id, "pagerduty_service.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceWithSupportHoursConfigUpdated(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					testAccCheckPagerDutyServiceSaveServiceId(p_updated_service_id, "pagerduty_service.foo"),
+				),
+			},
+		},
+	})
+
+	if service_id != updated_service_id {
+		t.Error(fmt.Errorf("Expected service id to be %s, but found %s", service_id, updated_service_id))
+	}
+}
+
+func testAccCheckPagerDutyServiceSaveServiceId(p *string, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Service ID is set")
+		}
+
+		*p = rs.Primary.ID
+
+		return nil
+	}
+}
+
 func testAccCheckPagerDutyServiceDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*pagerduty.Client)
 	for _, r := range s.RootModule().Resources {
@@ -645,6 +744,136 @@ resource "pagerduty_service" "foo" {
 		start_time   = "09:00:00"
 		end_time     = "17:00:00"
 		days_of_week = [ 1, 2, 3, 4, 5 ]
+	}]
+
+	scheduled_actions {
+		type = "urgency_change"
+		to_urgency = "high"
+		at {
+			type = "named_time",
+			name = "support_hours_start"
+		}
+	}
+}
+`, username, email, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyServiceWithScheduledActionsConfigUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+	name        = "%s"
+	email       = "%s"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "%s"
+	description = "bar"
+	num_loops   = 2
+
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+	incident_urgency_rule {
+		type = "use_support_hours"
+
+		during_support_hours {
+			type    = "constant"
+			urgency = "low"
+		}
+		outside_support_hours {
+			type    = "constant"
+			urgency = "high"
+		}
+	}
+
+	support_hours = [{
+		type         = "fixed_time_per_day"
+		time_zone    = "America/Lima"
+		start_time   = "09:00:00"
+		end_time     = "17:00:00"
+		days_of_week = [ 1, 2, 3, 4, 5 ]
+	}]
+
+	scheduled_actions {
+		type = "urgency_change"
+		to_urgency = "high"
+		at {
+			type = "named_time",
+			name = "support_hours_end"
+		}
+	}
+}
+`, username, email, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyServiceWithSupportHoursConfigUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+	name        = "%s"
+	email       = "%s"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "%s"
+	description = "bar"
+	num_loops   = 2
+
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+	incident_urgency_rule {
+		type = "use_support_hours"
+
+		during_support_hours {
+			type    = "constant"
+			urgency = "high"
+		}
+		outside_support_hours {
+			type    = "constant"
+			urgency = "low"
+		}
+	}
+
+	support_hours = [{
+		type         = "fixed_time_per_day"
+		time_zone    = "America/Lima"
+		start_time   = "08:00:00"
+		end_time     = "18:00:00"
+		days_of_week = [ 1, 2, 3, 4 ]
 	}]
 
 	scheduled_actions {

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -63,8 +63,7 @@ The block contains the following arguments.
   * `during_support_hours` - (Optional) Incidents' urgency during support hours.
   * `outside_support_hours` - (Optional) Incidents' urgency outside of support hours.
 
-When using `type = "use_support_hours"` in `incident_urgency_rule` you have to specify exactly one otherwise optional `support_hours` block.
-Changes to `support_hours` necessitate re-creating the service resource. Account must have the `service_support_hours` ability to assign support hours.
+When using `type = "use_support_hours"` in `incident_urgency_rule` you have to specify exactly one otherwise optional `support_hours` block. Account must have the `service_support_hours` ability to assign support hours.
 The block contains the following arguments.
 
   * `type` - The type of support hours. Can be `fixed_time_per_day`.
@@ -74,7 +73,7 @@ The block contains the following arguments.
   * `start_time` - The support hours' starting time of day.
   * `end_time` - The support hours' ending time of day.
 
-When using `type = "use_support_hours"` in the `incident_urgency_rule` block you have to also specify `scheduled_actions` for the service. Otherwise `scheduled_actions` is optional. Changes necessitate re-createing the service resource.
+When using `type = "use_support_hours"` in the `incident_urgency_rule` block you have to also specify `scheduled_actions` for the service. Otherwise `scheduled_actions` is optional.
 
   * `type` - The type of scheduled action. Currently, this must be set to `urgency_change`.
   * `at` - Represents when scheduled action will occur.


### PR DESCRIPTION
We have added a fix so that services don't get recreated when we change scheduled action or support hours. Fixes #53 

Acceptance tests results : 
```
➜  terraform-provider-pagerduty git:(service-recreate) ✗ TF_ACC=1 go test github.com/terraform-providers/terraform-provider-pagerduty/pagerduty -v -run=TestAccPagerDutyService_SupportHoursChange -timeout 120m
=== RUN   TestAccPagerDutyService_SupportHoursChange
--- PASS: TestAccPagerDutyService_SupportHoursChange (19.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	19.441s

```