### PR TITLE
Enable extensions in the provider

### DIFF
--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -50,7 +50,7 @@ func dataSourcePagerDutyExtensionSchemaRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(found.ID)
-	d.Set("label", found.Label)
+	d.Set("name", found.Label)
 	d.Set("type", found.Type)
 
 	return nil

--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -1,0 +1,75 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyExtensionSchema() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyExtensionSchemaRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `name` instead. This attribute will be removed in a future version",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyExtensionSchemaRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty Extension Schema")
+
+	searchName := d.Get("name").(string)
+
+	resp, _, err := client.ExtensionSchemas.List()
+	if err != nil {
+		return err
+	}
+
+	var found *pagerduty.ExtensionSchema = findExtensionSchema(resp.ExtensionSchemas, searchName)
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any extension schema with the name: %s", searchName)
+	}
+
+	d.SetId(found.ID)
+	d.Set("label", found.Label)
+	d.Set("type", found.Type)
+
+	return nil
+}
+
+func findExtensionSchema(extensionSchemas []*pagerduty.ExtensionSchema, searchName string) *pagerduty.ExtensionSchema {
+	r := regexp.MustCompile("(?i)" + searchName)
+	var closeMatch *pagerduty.ExtensionSchema
+	for _, extensionSchema := range extensionSchemas {
+		if searchName == extensionSchema.Label {
+			return extensionSchema
+		}
+		if r.MatchString(extensionSchema.Label) {
+			closeMatch = extensionSchema
+		}
+	}
+
+	if closeMatch != nil {
+		return closeMatch
+	}
+	return nil
+}

--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -14,11 +14,6 @@ func dataSourcePagerDutyExtensionSchema() *schema.Resource {
 		Read: dataSourcePagerDutyExtensionSchemaRead,
 
 		Schema: map[string]*schema.Schema{
-			"name_regex": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Removed:  "Use `name` instead. This attribute will be removed in a future version",
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/pagerduty/data_source_pagerduty_extension_schema_test.go
+++ b/pagerduty/data_source_pagerduty_extension_schema_test.go
@@ -1,0 +1,57 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourcePagerDutyExtensionSchema_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyExtensionSchemaConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyExtensionSchema("data.pagerduty_extension_schema.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyExtensionSchema(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get an Extension Schema  ID from PagerDuty")
+		}
+
+		if a["id"] != "PD8SURB" {
+			return fmt.Errorf("Expected the Slack Extension Schema ID to be: PD8SURB, but got: %s", a["id"])
+		}
+
+		if a["name"] != "slack" {
+			return fmt.Errorf("Expected the Slack Extension Schema Name to be: slack, but got: %s", a["name"])
+		}
+
+		if a["type"] != "extension_schema" {
+			return fmt.Errorf("Expected the Slack Extension Schema Type to be: extension_schema, but got: %s", a["type"])
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourcePagerDutyExtensionSchemaConfig = `
+data "pagerduty_extension_schema" "foo" {
+  name = "slack"
+}
+`

--- a/pagerduty/data_source_pagerduty_extension_schema_test.go
+++ b/pagerduty/data_source_pagerduty_extension_schema_test.go
@@ -38,8 +38,8 @@ func testAccDataSourcePagerDutyExtensionSchema(n string) resource.TestCheckFunc 
 			return fmt.Errorf("Expected the Slack Extension Schema ID to be: PD8SURB, but got: %s", a["id"])
 		}
 
-		if a["name"] != "slack" {
-			return fmt.Errorf("Expected the Slack Extension Schema Name to be: slack, but got: %s", a["name"])
+		if a["name"] != "Slack" {
+			return fmt.Errorf("Expected the Slack Extension Schema Name to be: Slack, but got: %s", a["name"])
 		}
 
 		if a["type"] != "extension_schema" {

--- a/pagerduty/import_pagerduty_extension_test.go
+++ b/pagerduty/import_pagerduty_extension_test.go
@@ -1,0 +1,32 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPagerDutyExtension_import(t *testing.T) {
+	extension_name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	url := "https://example.com/receive_a_pagerduty_webhook"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyExtensionConfig(name, extension_name, url),
+			},
+
+			{
+				ResourceName:      "pagerduty_extension.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -45,6 +45,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_team_membership":     resourcePagerDutyTeamMembership(),
 			"pagerduty_user":                resourcePagerDutyUser(),
 			"pagerduty_user_contact_method": resourcePagerDutyUserContactMethod(),
+			"pagerduty_extension":           resourcePagerDutyExtension(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -31,6 +31,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_schedule":          dataSourcePagerDutySchedule(),
 			"pagerduty_user":              dataSourcePagerDutyUser(),
 			"pagerduty_vendor":            dataSourcePagerDutyVendor(),
+			"pagerduty_extension_schema":  dataSourcePagerDutyExtensionSchema(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -1,0 +1,139 @@
+package pagerduty
+
+import (
+	"log"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyExtension() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyExtensionCreate,
+		Read:   resourcePagerDutyExtensionRead,
+		Update: resourcePagerDutyExtensionUpdate,
+		Delete: resourcePagerDutyExtensionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourcePagerDutyExtensionImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"endpoint_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"extension_objects": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"extension_schema": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+		},
+	}
+}
+
+func buildExtensionStruct(d *schema.ResourceData) *pagerduty.Extension {
+	Extension := &pagerduty.Extension{
+		Name:        d.Get("name").(string),
+		Type:        "extension",
+		EndpointURL: d.Get("endpoint_url").(string),
+		ExtensionSchema: &pagerduty.ExtensionSchemaReference{
+			Type: "extension_schema_reference",
+			ID:   d.Get("extension_schema").(string),
+		},
+		ExtensionObjects: expandServices(d.Get("extension_objects")),
+	}
+
+	return Extension
+}
+
+func resourcePagerDutyExtensionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	Extension := buildExtensionStruct(d)
+
+	log.Printf("[INFO] Creating PagerDuty extension %s", Extension.Name)
+
+	Extension, _, err := client.Extensions.Create(Extension)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(Extension.ID)
+
+	return nil
+}
+
+func resourcePagerDutyExtensionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty extension %s", d.Id())
+
+	extension, _, err := client.Extensions.Get(d.Id())
+	if err != nil {
+		return handleNotFoundError(err, d)
+	}
+
+	d.Set("name", extension.Name)
+
+	return nil
+}
+
+func resourcePagerDutyExtensionUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	extension := buildExtensionStruct(d)
+
+	log.Printf("[INFO] Updating PagerDuty extension %s", d.Id())
+
+	if _, _, err := client.Extensions.Update(d.Id(), extension); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourcePagerDutyExtensionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Deleting PagerDuty extension %s", d.Id())
+
+	if _, err := client.Extensions.Delete(d.Id()); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourcePagerDutyExtensionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*pagerduty.Client)
+
+	extension, _, err := client.Extensions.Get(d.Id())
+
+	if err != nil {
+		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_extension. Expecting an importation ID for extension.")
+	}
+
+	d.Set("endpoint_url", extension.EndpointURL)
+	d.Set("extension_objects", []string{extension.ExtensionObjects[0].ID})
+	d.Set("extension_schema", extension.ExtensionSchema.ID)
+
+	return []*schema.ResourceData{d}, err
+}

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -89,8 +89,8 @@ func resourcePagerDutyExtensionRead(d *schema.ResourceData, meta interface{}) er
 		return handleNotFoundError(err, d)
 	}
 
-	d.Set("name", extension.Name)
 	d.Set("summary", extension.Summary)
+	d.Set("name", extension.Name)
 	d.Set("endpoint_url", extension.EndpointURL)
 	d.Set("extension_objects", extension.ExtensionObjects)
 	d.Set("extension_schema", extension.ExtensionSchema)

--- a/pagerduty/resource_pagerduty_extension_test.go
+++ b/pagerduty/resource_pagerduty_extension_test.go
@@ -1,0 +1,181 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_extension", &resource.Sweeper{
+		Name: "pagerduty_extension",
+		F:    testSweepExtension,
+	})
+}
+
+func testSweepExtension(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.Extensions.List(&pagerduty.ListExtensionsOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, extension := range resp.Extensions {
+		if strings.HasPrefix(extension.Name, "test") || strings.HasPrefix(extension.Name, "tf-") {
+			log.Printf("Destroying extension %s (%s)", extension.Name, extension.ID)
+			if _, err := client.Extensions.Delete(extension.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyExtension_Basic(t *testing.T) {
+	extension_name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	extension_name_updated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	url := "https://example.com/recieve_a_pagerduty_webhook"
+	url_updated := "https://example.com/webhook_foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyExtensionConfig(name, extension_name, url),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyExtensionExists("pagerduty_extension.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "name", extension_name),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "extension_schema", "PJFWPEP"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "endpoint_url", url),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyExtensionConfig(name, extension_name_updated, url_updated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyExtensionExists("pagerduty_extension.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "name", extension_name_updated),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "extension_schema", "PJFWPEP"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "endpoint_url", url_updated),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyExtensionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_extension" {
+			continue
+		}
+
+		if _, _, err := client.Extensions.Get(r.Primary.ID); err == nil {
+			return fmt.Errorf("Extension still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyExtensionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No extension ID is set")
+		}
+
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		found, _, err := client.Extensions.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Extension not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyExtensionConfig(name string, extension_name string, url string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[1]v@foo.com"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%[1]v"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%[1]v"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+data "pagerduty_extension_schema" "foo" {
+	name = "Generic V2 Webhook"
+}
+
+resource "pagerduty_extension" "foo"{
+  name = "%s"
+  endpoint_url = "%s"
+  extension_schema = "${data.pagerduty_extension_schema.foo.id}"
+  extension_objects    = ["${pagerduty_service.foo.id}"]
+}
+`, name, extension_name, url)
+}

--- a/pagerduty/resource_pagerduty_extension_test.go
+++ b/pagerduty/resource_pagerduty_extension_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/heimweh/go-pagerduty/pagerduty"
@@ -48,9 +47,9 @@ func testSweepExtension(region string) error {
 }
 
 func TestAccPagerDutyExtension_Basic(t *testing.T) {
-	extension_name := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	extension_name_updated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	extension_name := resource.PrefixedUniqueId("tf")
+	extension_name_updated := resource.PrefixedUniqueId("tf")
+	name := resource.PrefixedUniqueId("tf")
 	url := "https://example.com/recieve_a_pagerduty_webhook"
 	url_updated := "https://example.com/webhook_foo"
 

--- a/vendor/github.com/heimweh/go-pagerduty/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/heimweh/go-pagerduty/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at heimweh@users.noreply.github.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/vendor/github.com/heimweh/go-pagerduty/Makefile
+++ b/vendor/github.com/heimweh/go-pagerduty/Makefile
@@ -1,0 +1,88 @@
+SHELL=bash
+OK_MSG = \x1b[32m ✔\x1b[0m
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+GOLIST?=$$(go list ./... | grep -v vendor)
+
+default: test
+
+integration:
+	go test -v ./tests/integration
+
+# tools fetches necessary dev requirements
+tools:
+	go get -u github.com/robertkrimen/godocdown/godocdown
+	go get -u github.com/kardianos/govendor
+	go get -u honnef.co/go/tools/cmd/gosimple
+	go get -u honnef.co/go/tools/cmd/unused
+	go get -u honnef.co/go/tools/cmd/staticcheck
+	go get -u github.com/client9/misspell/cmd/misspell
+	go get -u github.com/golang/lint/golint
+
+vendor-status:
+	@govendor status
+
+coverprofile:
+	@go test ./pagerduty/... -coverprofile coverage.out && go tool cover -html=coverage.out
+
+lint:
+	@echo -n "==> Checking that code complies with golint requirements..."
+	@ret=0 && for pkg in $(GOLIST); do \
+		test -z "$$(golint $$pkg | tee /dev/stderr)" || ret=1; \
+		done ; exit $$ret
+	@echo -e "$(OK_MSG)"
+
+# check combines all checks into a single command
+check: fmtcheck vet misspell staticcheck simple unused lint vendor-status
+
+# fmt formats Go code.
+fmt:
+	gofmt -w $(GOFMT_FILES)
+
+test: check
+	@echo "==> Checking that code complies with unit tests..."
+	@go test $(GOLIST) -cover
+
+webdoc:
+	@echo "==> Starting webserver at http://localhost:6060"
+	@sleep 1 && open http://localhost:6060 &
+	@godoc -http=:6060
+
+unused:
+	@echo -n "==> Checking that code complies with unused requirements..."
+	@unused $(GOLIST)
+	@echo -e "$(OK_MSG)"
+
+fmtcheck:
+	@echo -n "==> Checking that code complies with gofmt requirements..."
+	@gofmt_files=$$(gofmt -l $(GOFMT_FILES)) ; if [[ -n "$$gofmt_files" ]]; then \
+		echo 'gofmt needs running on the following files:'; \
+		echo "$$gofmt_files"; \
+		echo "You can use the command: \`make fmt\` to reformat code."; \
+		exit 1; \
+	fi
+	@echo -e "$(OK_MSG)"
+
+misspell:
+	@echo -n "==> Checking for misspelling errors..."
+	@misspell --error $(GOFMT_FILES)
+	@echo -e "$(OK_MSG)"
+
+simple:
+	@echo -n "==> Checking that code complies with gosimple requirements..."
+	@gosimple $(GOLIST)
+	@echo -e "$(OK_MSG)"
+
+staticcheck:
+	@echo -n "==> Checking that code complies with staticcheck requirements..."
+	@staticcheck $(GOLIST)
+	@echo -e "$(OK_MSG)"
+
+vet:
+	@echo -n "==> Checking that code complies with go vet requirements..."
+	@go vet $(GOLIST) ; if [ $$? -eq 1 ]; then \
+		echo ""; \
+		echo "Vet found suspicious constructs. Please check the reported constructs"; \
+		echo "and fix them if necessary before submitting the code for review."; \
+		exit 1; \
+	fi
+	@echo -e "$(OK_MSG)"

--- a/vendor/github.com/heimweh/go-pagerduty/README.md
+++ b/vendor/github.com/heimweh/go-pagerduty/README.md
@@ -1,0 +1,43 @@
+# go-pagerduty
+PagerDuty API client in Go, primarily used by the [PagerDuty](https://github.com/terraform-providers/terraform-provider-pagerduty) provider in Terraform.
+
+
+[![GoDoc](https://godoc.org/github.com/heimweh/go-pagerduty?status.svg)](http://godoc.org/github.com/heimweh/go-pagerduty/pagerduty)
+[![Build
+Status](https://travis-ci.org/heimweh/go-pagerduty.svg?branch=master)](https://travis-ci.org/heimweh/go-pagerduty)
+
+
+## Installation
+```bash
+go get github.com/heimweh/go-pagerduty
+```
+
+## Example usage
+```go
+func main() {
+  client, err := pagerduty.NewClient(&Config{Token: "foo"})
+  if err != nil {
+    panic(err)
+  }
+
+  // List all users
+  resp, raw, err := client.Users.List(&pagerduty.ListUsersOptions{})
+  if err != nil {
+    panic(err)
+  }
+
+  for _, user := range resp.Users {
+    fmt.Println(user.Name)
+  }
+
+  // All calls returns the raw *http.Response for further inspection
+  fmt.Println(raw.StatusCode)
+}
+```
+
+## Contributing
+1. Fork it ( https://github.com/heimweh/go-pagerduty/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension.go
@@ -1,0 +1,95 @@
+package pagerduty
+
+import "fmt"
+
+// ExtensionService handles the communication with extension related methods
+// of the PagerDuty API.
+type ExtensionService service
+
+// Extension represents an extension.
+type Extension struct {
+	Extension        *Extension                `json:"extension,omitempty"`
+	ID               string                    `json:"id,omitempty"`
+	Summary          string                    `json:"summary,omitempty"`
+	Type             string                    `json:"type,omitempty"`
+	Self             string                    `json:"self,omitempty"`
+	HTMLURL          string                    `json:"html_url,omitempty"`
+	Name             string                    `json:"name"`
+	EndpointURL      string                    `json:"endpoint_url,omitempty"`
+	ExtensionObjects []*ServiceReference       `json:"extension_objects,omitempty"`
+	ExtensionSchema  *ExtensionSchemaReference `json:"extension_schema"`
+}
+
+// ListExtensionsOptions represents options when listing extensions.
+type ListExtensionsOptions struct {
+	ExtensionObjectID string   `url:"extension_object_id,omitempty"`
+	Query             string   `url:"query,omitempty"`
+	ExtensionSchemaID string   `url:"extension_schema_id,omitempty"`
+	Include           []string `url:"include,omitempty,brackets"`
+}
+
+// ListExtensionsResponse represents a list response of extensions.
+type ListExtensionsResponse struct {
+	Limit      int          `json:"limit,omitempty"`
+	Extensions []*Extension `json:"extensions,omitempty"`
+	More       bool         `json:"more,omitempty"`
+	Offset     int          `json:"offset,omitempty"`
+	Total      int          `json:"total,omitempty"`
+}
+
+// List lists existing extensions.
+func (s *ExtensionService) List(o *ListExtensionsOptions) (*ListExtensionsResponse, *Response, error) {
+	u := "/extensions"
+	v := new(ListExtensionsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Create creates a new extension.
+func (s *ExtensionService) Create(extension *Extension) (*Extension, *Response, error) {
+	u := "/extensions"
+	v := new(Extension)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, &Extension{Extension: extension}, v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Extension, resp, nil
+}
+
+// Delete removes an existing extension.
+func (s *ExtensionService) Delete(id string) (*Response, error) {
+	u := fmt.Sprintf("/extensions/%s", id)
+	return s.client.newRequestDo("DELETE", u, nil, nil, nil)
+}
+
+// Get retrieves information about an extension.
+func (s *ExtensionService) Get(id string) (*Extension, *Response, error) {
+	u := fmt.Sprintf("/extensions/%s", id)
+	v := new(Extension)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Extension, resp, nil
+}
+
+// Update updates an existing extension.
+func (s *ExtensionService) Update(id string, extension *Extension) (*Extension, *Response, error) {
+	u := fmt.Sprintf("/extensions/%s", id)
+	v := new(Extension)
+	resp, err := s.client.newRequestDo("PUT", u, nil, &Extension{Extension: extension}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Extension, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension_schema.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension_schema.go
@@ -1,0 +1,60 @@
+package pagerduty
+
+import "fmt"
+
+// ExtensionSchemaService handles the communication with extension schemas related methods
+// of the PagerDuty API.
+type ExtensionSchemaService service
+
+// ExtensionSchema represents an extension schema.
+type ExtensionSchema struct {
+	ExtensionSchema *ExtensionSchema `json:"extension_schema,omitempty"`
+	Description     string           `json:"description,omitempty"`
+	GuideURL        string           `json:"guide_url,omitempty"`
+	HTMLURL         string           `json:"html_url,omitempty"`
+	IconURL         string           `json:"icon_url,omitempty"`
+	ID              string           `json:"id,omitempty"`
+	Key             string           `json:"key,omitempty"`
+	Label           string           `json:"label,omitempty"`
+	LogoURL         string           `json:"logo_url,omitempty"`
+	Self            string           `json:"self,omitempty"`
+	SendTypes       []string         `json:"send_types,omitempty"`
+	Summary         string           `json:"summary,omitempty"`
+	Type            string           `json:"type,omitempty"`
+	URL             string           `json:"url,omitempty"`
+}
+
+// ListExtensionSchemasResponse represents a list response of extension schemas.
+type ListExtensionSchemasResponse struct {
+	ExtensionSchemas []*ExtensionSchema `json:"extension_schemas,omitempty"`
+	Limit            int                `json:"limit,omitempty"`
+	More             bool               `json:"more,omitempty"`
+	Offset           int                `json:"offset,omitempty"`
+	Total            int                `json:"total,omitempty"`
+}
+
+// List lists extension schemas.
+func (s *ExtensionSchemaService) List() (*ListExtensionSchemasResponse, *Response, error) {
+	u := "/extension_schemas"
+	v := new(ListExtensionSchemasResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Get retrieves information about an extension schema.
+func (s *ExtensionSchemaService) Get(id string) (*ExtensionSchema, *Response, error) {
+	u := fmt.Sprintf("/extension_schemas/%s", id)
+	v := new(ExtensionSchema)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.ExtensionSchema, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -37,10 +37,12 @@ type Client struct {
 	Abilities          *AbilityService
 	Addons             *AddonService
 	EscalationPolicies *EscalationPolicyService
+	Extensions         *ExtensionService
 	MaintenanceWindows *MaintenanceWindowService
 	Schedules          *ScheduleService
 	Services           *ServicesService
 	Teams              *TeamService
+	ExtensionSchemas   *ExtensionSchemaService
 	Users              *UserService
 	Vendors            *VendorService
 }
@@ -80,6 +82,8 @@ func NewClient(config *Config) (*Client, error) {
 	c.Teams = &TeamService{c}
 	c.Users = &UserService{c}
 	c.Vendors = &VendorService{c}
+	c.Extensions = &ExtensionService{c}
+	c.ExtensionSchemas = &ExtensionSchemaService{c}
 
 	return c, nil
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
@@ -42,3 +42,6 @@ type EscalationTargetReference resourceReference
 
 // VendorReference represents a reference to a vendor
 type VendorReference resourceReference
+
+// ExtensionSchemaReference represents a reference to an extension schema
+type ExtensionSchemaReference resourceReference

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -522,10 +522,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "ZQ0pchJreisfmNgJq387N9kqA+w=",
+			"checksumSHA1": "H0Vs09RBkizBDrh8VTr6yI1vaDs=",
 			"path": "github.com/heimweh/go-pagerduty/pagerduty",
-			"revision": "64f5bd2f9c706f1b708fa7cc4e511611bc307890",
-			"revisionTime": "2017-11-24T16:45:11Z"
+			"revision": "5536d50d2555892a2cdc778f9717d30d926c4566",
+			"revisionTime": "2017-12-06T09:33:38Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",

--- a/website/docs/d/extension_schema.html.markdown
+++ b/website/docs/d/extension_schema.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_extension_schema"
+sidebar_current: "docs-pagerduty-datasource-extension-schema"
+description: |-
+  Get information about an extension vendor that you can use for a service (e.g: Slack, Generic Webhook, ServiceNow).
+
+# pagerduty\_extension\_schema
+
+Use this data source to get information about a specific [extension][1] vendor that you can use for a service (e.g: Slack, Generic Webhook, ServiceNow).
+
+## Example Usage
+
+```hcl
+data "pagerduty_extension_schema" "webhook" {
+  name = "Generic V2 Webhook"
+}
+
+resource "pagerduty_user" "example" {
+  name  = "Howard James"
+  email = "howard.james@example.domain"
+  teams = ["${pagerduty_team.example.id}"]
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user"
+      id   = "${pagerduty_user.example.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "example" {
+  name                    = "My Web App"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = 600
+  escalation_policy       = "${pagerduty_escalation_policy.example.id}"
+}
+
+
+resource "pagerduty_extension" "slack"{
+  name = "My Web App Extension"
+  endpoint_url = "https://generic_webhook_url/XXXXXX/BBBBBB"
+  extension_schema = "${data.pagerduty_extension_schema.webhook.id}"
+  extension_objects    = ["${pagerduty_service.example.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The extension name to use to find an extension vendor in the PagerDuty API.
+
+## Attributes Reference
+* `name` - The short name of the found extension vendor.
+* `type` - The generic service type for this extension vendor.
+
+[1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extension_Schemas/get_extension_schemas

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_extension
 
-A [extension](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extensions/post_extensions) can be associated with a service.
+An [extension](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extensions/post_extensions) can be associated with a service.
 
 ## Example Usage
 

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_extension"
+sidebar_current: "docs-pagerduty-resource-extension"
+description: |-
+  Creates and manages a service extension in PagerDuty.
+---
+
+# pagerduty\_extension
+
+A [extension](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extensions/post_extensions) can be associated with a service.
+
+## Example Usage
+
+```hcl
+data "pagerduty_extension_schema" "webhook" {
+  name = "Generic V2 Webhook"
+}
+
+resource "pagerduty_user" "example" {
+  name  = "Howard James"
+  email = "howard.james@example.domain"
+  teams = ["${pagerduty_team.example.id}"]
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user"
+      id   = "${pagerduty_user.example.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "example" {
+  name                    = "My Web App"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = 600
+  escalation_policy       = "${pagerduty_escalation_policy.example.id}"
+}
+
+
+resource "pagerduty_extension" "slack"{
+  name = "My Web App Extension"
+  endpoint_url = "https://generic_webhook_url/XXXXXX/BBBBBB"
+  extension_schema = "${data.pagerduty_extension_schema.webhook.id}"
+  extension_objects    = ["${pagerduty_service.example.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Optional) The name of the service extension.
+  * `endpoint_url` - (Required) The url of the extension.
+  * `extension_schema` - (Required) This is the schema for this extension.
+  * `extension_objects` - (Required) This is the objects for which the extension applies (An array of service ids).
+
+    **Note:** You can use the `pagerduty_extension_schema` data source to locate the appropriate extension vendor ID.
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the extension.
+  * `html_url` - a URL at which the entity is uniquely displayed in the Web app
+
+## Import
+
+Extensions can be imported using the id.e.g.
+
+```
+$ terraform import pagerduty_extension.main PLBP09X
+
+```
+

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -16,6 +16,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-escalation-policy") %>>
                     <a href="/docs/providers/pagerduty/d/escalation_policy.html">pagerduty_escalation_policy</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-extension-schema") %>>
+                    <a href="/docs/providers/pagerduty/d/extension_schema.html">pagerduty_extension_schema</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-schedule") %>>
                     <a href="/docs/providers/pagerduty/d/schedule.html">pagerduty_schedule</a>
                 </li>
@@ -37,6 +40,9 @@
                 <li<%= sidebar_current("docs-pagerduty-resource-escalation_policy") %>>
                     <a href="/docs/providers/pagerduty/r/escalation_policy.html">pagerduty_escalation_policy</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-extension") %>>
+                    <a href="/docs/providers/pagerduty/r/extension.html">pagerduty_extension</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-maintenance_window") %>>
                     <a href="/docs/providers/pagerduty/r/maintenance_window.html">pagerduty_maintenance_window</a>
                 </li>
@@ -57,6 +63,9 @@
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
                     <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-user-contact-method") %>>
+                    <a href="/docs/providers/pagerduty/r/user_contact_method.html">pagerduty_user_contact_method</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-user-contact-method") %>>
                     <a href="/docs/providers/pagerduty/r/user_contact_method.html">pagerduty_user_contact_method</a>


### PR DESCRIPTION
This PR contains following changes

1. Updated client version so that it supports extensions
2. Added data source and acceptance test for extension schema
3. Added resource 'extension' and acceptance tests
4. Documentation on extensions

Test results:
```
➜  terraform-provider-pagerduty git:(extensions) ✗ TF_ACC=1 go test github.com/terraform-providers/terraform-provider-pagerduty/pagerduty -v -run=TestAccDataSourcePagerDutyExtensionSchema_Basic -timeout 120m
=== RUN   TestAccDataSourcePagerDutyExtensionSchema_Basic
--- PASS: TestAccDataSourcePagerDutyExtensionSchema_Basic (5.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	5.740s

➜  terraform-provider-pagerduty git:(extensions) ✗ TF_ACC=1 go test github.com/terraform-providers/terraform-provider-pagerduty/pagerduty -v -run=TestAccPagerDutyExtension_Basic -timeout 120m
=== RUN   TestAccPagerDutyExtension_Basic
--- PASS: TestAccPagerDutyExtension_Basic (22.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	22.759s
```

Please let me know if any changes are needed.