### PR TITLE
Error check extension_object read in PagerDuty Extensions; use flatten method

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -93,7 +93,9 @@ func resourcePagerDutyExtensionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("summary", extension.Summary)
 	d.Set("name", extension.Name)
 	d.Set("endpoint_url", extension.EndpointURL)
-	d.Set("extension_objects", extension.ExtensionObjects)
+	if err := d.Set("extension_objects", flattenExtensionObjects(extension.ExtensionObjects)); err != nil {
+		log.Printf("[WARN] error setting extension_objects: %s", err)
+	}
 	d.Set("extension_schema", extension.ExtensionSchema)
 
 	return nil
@@ -158,5 +160,17 @@ func expandServiceObjects(v interface{}) []*pagerduty.ServiceReference {
 		services = append(services, service)
 	}
 
+	return services
+}
+
+func flattenExtensionObjects(serviceList []*pagerduty.ServiceReference) interface{} {
+	var services []interface{}
+	for _, s := range serviceList {
+		// only flatten service_reference types, because that's all we send at this
+		// time
+		if s.Type == "service_reference" {
+			services = append(services, s.ID)
+		}
+	}
 	return services
 }


### PR DESCRIPTION
Hello! #69 added `pagerduty_extension` resource, and only too late did I notice that we aren't checking the error when setting the non-scalar value `extension_object`. Sure enough, it was returning an error due to incompatible format:

```
2018-03-08T12:09:05.781-0600 [DEBUG] plugin.terraform-provider-pagerduty: 2018/03/08 12:09:05 [WARN] error setting extension_objects: extension_objects.0: '' expected type 'string', got unconvertible type '*pagerduty.ServiceReference'
```

This means reading from the API would not detect drift, should something have changed outside of Terraform. `extension_object` is a `ForceNew` attribute, so perhaps that's not possible anyway (the extension we know may be recreated with a new ID if changed externally). 

Either way, I add check the error here and add a `flattenExtensionObjects` method.