### PR TITLE
Create Dockerfile to enable easier local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.8-alpine3.6
+
+ENV TERRAFORM_VERSION=0.10.0
+
+RUN apk add --update git bash openssh alpine-sdk
+
+ENV TF_DEV=true
+ENV TF_RELEASE=true
+
+WORKDIR $GOPATH/src/github.com/hashicorp/terraform
+RUN git clone https://github.com/hashicorp/terraform.git ./ && \
+    git checkout v${TERRAFORM_VERSION} && \
+    /bin/bash scripts/build.sh
+
+ENV PROVIDER_NAME=terraform-provider-pagerduty
+ENV PROVIDER_DIR=${GOPATH}/src/github.com/terraform-providers/${PROVIDER_NAME}
+COPY . ${PROVIDER_DIR}
+
+WORKDIR ${PROVIDER_DIR}
+RUN make build
+
+ENTRYPOINT ["sh"]

--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+## Developing with Docker
+
+Running the following commands will build the docker image and run the container with the code volume mounted to the correct location:
+```sh
+$ docker build -t terraform-provider-pagerduty .
+$ docker run -v $(pwd):/go/src/github.com/terraform-providers/terraform-provider-pagerduty -it terraform-provider-pagerduty
+```


### PR DESCRIPTION
Created a Dockerfile loaded with Go 1.8 and Terraform, figured it would be easier for local development. Might be worth thinking about a test API token for the acceptance tests, mainly due to the fact that some people might not have account features necessary for running these tests.