### PR TITLE
Declare extension endpoint URL as optional as documented in API

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -31,7 +31,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 			},
 			"endpoint_url": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"extension_objects": {
 				Type:     schema.TypeSet,

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -58,7 +58,7 @@ resource "pagerduty_extension" "slack"{
 The following arguments are supported:
 
   * `name` - (Optional) The name of the service extension.
-  * `endpoint_url` - (Required) The url of the extension.
+  * `endpoint_url` - (Optional) The url of the extension.
   * `extension_schema` - (Required) This is the schema for this extension.
   * `extension_objects` - (Required) This is the objects for which the extension applies (An array of service ids).
 


### PR DESCRIPTION
The extension endpoint URL is optional as documented in API: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extensions/post_extensions

Most notably, it is not needed for some extensions vendors like Slack.

Current work-around: pass an empty string which is not sent to API because of the `omitempty`.