### PR TITLE
resource/pagerduty_user_contact_method: Add support for push_notification_contact_method

### DIFF
--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -30,6 +30,7 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 				ValidateFunc: validateValueFunc([]string{
 					"email_contact_method",
 					"phone_contact_method",
+					"push_notification_contact_method",
 					"sms_contact_method",
 				}),
 			},

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -49,7 +49,7 @@ resource "pagerduty_user_contact_method" "sms" {
 The following arguments are supported:
 
   * `user_id` - (Required) The ID of the user.
-  * `type` - (Required) The contact method type. May be (`email_contact_method`, `phone_contact_method`, `sms_contact_method`).
+  * `type` - (Required) The contact method type. May be (`email_contact_method`, `phone_contact_method`, `sms_contact_method`, `push_notification_contact_method`).
   * `send_short_email` - (Optional) Send an abbreviated email message instead of the standard email output.
   * `country_code` - (Optional) The 1-to-3 digit country calling code. Required when using `phone_contact_method` or `sms_contact_method`.
   * `label` - (Required) The label (e.g., "Work", "Mobile", etc.).


### PR DESCRIPTION
Fixes #86 by adding push_notification_contact_method to the list of available types.

API reference: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Users/post_users_id_contact_methods