### PR TITLE
Instantiate scheduled_actions if incident_urgency_rules with type = "use_support_hours"

### DIFF
--- a/pagerduty/data_source_pagerduty_vendor_test.go
+++ b/pagerduty/data_source_pagerduty_vendor_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourcePagerDutyVendor_Basic(t *testing.T) {
 				Config: testAccDataSourcePagerDutyVendorConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "id", "PZQ6AUS"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", "Amazon Cloudwatch"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "Amazon CloudWatch"),
 				),
 			},
 		},

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -229,7 +229,7 @@ func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 
 	if attr, ok := d.GetOk("incident_urgency_rule"); ok {
 		service.IncidentUrgencyRule = expandIncidentUrgencyRule(attr)
-		if service.IncidentUrgencyRule != nil && service.IncidentUrgencyRule.Type == "use_support_hours" {
+		if service.IncidentUrgencyRule.Type == "use_support_hours" {
 			service.ScheduledActions = make([]*pagerduty.ScheduledAction, 1)
 		}
 	}

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -229,14 +229,17 @@ func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 
 	if attr, ok := d.GetOk("incident_urgency_rule"); ok {
 		service.IncidentUrgencyRule = expandIncidentUrgencyRule(attr)
-	}
-
-	if attr, ok := d.GetOk("support_hours"); ok {
-		service.SupportHours = expandSupportHours(attr)
+		if service.IncidentUrgencyRule != nil && service.IncidentUrgencyRule.Type == "use_support_hours" {
+			service.ScheduledActions = make([]*pagerduty.ScheduledAction, 1)
+		}
 	}
 
 	if attr, ok := d.GetOk("scheduled_actions"); ok {
 		service.ScheduledActions = expandScheduledActions(attr)
+	}
+
+	if attr, ok := d.GetOk("support_hours"); ok {
+		service.SupportHours = expandSupportHours(attr)
 	}
 
 	return &service, nil


### PR DESCRIPTION
This fixes #97, instantiating scheduled actions if `use_support_hours` incident urgency type is set. It ensures that the pagerduty API calls will include an empty `scheduled_actions` in certain cases, explained better by the bug report in #97.