### PR TITLE
Docs: Include ID for all data source attributes

### DIFF
--- a/website/docs/d/escalation_policy.html.markdown
+++ b/website/docs/d/escalation_policy.html.markdown
@@ -5,7 +5,7 @@ sidebar_current: "docs-pagerduty-datasource-escalation-policy"
 description: |-
   Provides information about a Escalation Policy.
 
-  This data source can be helpful when an escalation policy is handled outside Terraform but still want to reference it in other resources.
+  This data source can be helpful when an escalation policy is handled outside Terraform but you still want to reference it in other resources.
 ---
 
 # pagerduty\_escalation_policy
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `name` - (Required) The name to use to find an escalation policy in the PagerDuty API.
 
 ## Attributes Reference
+* `id` - The ID of the found escalation policy.
 * `name` - The short name of the found escalation policy.
 
 [1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Escalation_Policies/get_escalation_policies

--- a/website/docs/d/extension_schema.html.markdown
+++ b/website/docs/d/extension_schema.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 * `name` - (Required) The extension name to use to find an extension vendor in the PagerDuty API.
 
 ## Attributes Reference
+* `id` - The ID of the found extension vendor.
 * `name` - The short name of the found extension vendor.
 * `type` - The generic service type for this extension vendor.
 

--- a/website/docs/d/schedule.html.markdown
+++ b/website/docs/d/schedule.html.markdown
@@ -5,7 +5,7 @@ sidebar_current: "docs-pagerduty-datasource-schedule"
 description: |-
   Provides information about a Schedule.
 
-  This data source can be helpful when a schedule is handled outside Terraform but still want to reference it in other resources.
+  This data source can be helpful when a schedule is handled outside Terraform but you still want to reference it in other resources.
 ---
 
 # pagerduty\_schedule
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `name` - (Required) The name to use to find a schedule in the PagerDuty API.
 
 ## Attributes Reference
+* `id` - The ID of the found schedule.
 * `name` - The short name of the found schedule.
 
 [1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Schedules/get_schedules

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -45,7 +45,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the team to find in the PagerDuty API.
 
 ## Attributes Reference
-* `name` - The name of the team.
-* `description` - A description of the team.
+* `id` - The ID of the found team.
+* `name` - The name of the found team.
+* `description` - A description of the found team.
 
 [1]: https://v1.developer.pagerduty.com/documentation/rest/teams/list

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `email` - (Required) The email to use to find a user in the PagerDuty API.
 
 ## Attributes Reference
+* `id` - The ID of the found user.
 * `name` - The short name of the found user.
 
 [1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Users/get_users

--- a/website/docs/d/vendor.html.markdown
+++ b/website/docs/d/vendor.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
 * `name` - (Required) The vendor name to use to find a vendor in the PagerDuty API.
 
 ## Attributes Reference
+* `id` - The ID of the found vendor.
 * `name` - The short name of the found vendor.
 * `type` - The generic service type for this vendor.
 


### PR DESCRIPTION
Every data source includes an ID attribute, but these were not documented. This fixes that omission.