### PR TITLE
Injecting the name search explicitly into the Team search

### DIFF
--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -33,7 +33,11 @@ func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error
 
 	searchTeam := d.Get("name").(string)
 
-	resp, _, err := client.Teams.List(&pagerduty.ListTeamsOptions{})
+	o := &pagerduty.ListTeamsOptions{
+		Query: searchTeam,
+	}
+
+	resp, _, err := client.Teams.List(o)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Running into an issue similar to issue https://github.com/terraform-providers/terraform-provider-pagerduty/issues/105 which seems to be related (in my case at least) to the 25 team limit in the pagerduty search.  

We could increase the search limit to an arbitrary large number but seeing as we need to provide the name for the search anyway and the query can use this, this seems like the simplest solution.

