### PR TITLE
resource/pagerduty_maintenance_window: Suppress spurious diff

### DIFF
--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -18,14 +18,16 @@ func resourcePagerDutyMaintenanceWindow() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"start_time": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateRFC3339,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateRFC3339,
+				DiffSuppressFunc: suppressRFC3339Diff,
 			},
 			"end_time": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateRFC3339,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateRFC3339,
+				DiffSuppressFunc: suppressRFC3339Diff,
 			},
 
 			"services": {

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,20 @@ func validateRFC3339(v interface{}, k string) (we []string, errors []error) {
 	}
 
 	return
+}
+
+func suppressRFC3339Diff(k, oldTime, newTime string, d *schema.ResourceData) bool {
+	oldT, err := time.Parse(time.RFC3339, oldTime)
+	if err != nil {
+		log.Printf("[ERROR] Failed to parse %q (old %q). Expected format: %s (RFC3339)", oldTime, k, time.RFC3339)
+		return false
+	}
+	newT, err := time.Parse(time.RFC3339, newTime)
+	if err != nil {
+		log.Printf("[ERROR] Failed to parse %q (new %q). Expected format: %s (RFC3339)", newTime, k, time.RFC3339)
+		return false
+	}
+	return oldT.Equal(newT)
 }
 
 // Validate a value against a set of possible values


### PR DESCRIPTION
This is to fix the following test failures:

```
=== RUN   TestAccPagerDutyMaintenanceWindow_Basic
--- FAIL: TestAccPagerDutyMaintenanceWindow_Basic (5.34s)
    testing.go:459: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: pagerduty_maintenance_window.foo
          end_time:   "2019-03-12T04:36:03+00:00" => "2019-03-12T04:36:03Z"
          start_time: "2019-03-11T04:36:03+00:00" => "2019-03-11T04:36:03Z"
        
=== RUN   TestAccPagerDutyMaintenanceWindow_import
--- FAIL: TestAccPagerDutyMaintenanceWindow_import (5.43s)
    testing.go:459: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: pagerduty_maintenance_window.foo
          end_time:   "2019-03-12T04:34:57+00:00" => "2019-03-12T04:34:57Z"
          start_time: "2019-03-11T04:34:57+00:00" => "2019-03-11T04:34:57Z"

```