### PR TITLE
tests: Fix sweeper dependencies

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -17,8 +17,7 @@ func init() {
 		Name: "pagerduty_escalation_policy",
 		F:    testSweepEscalationPolicy,
 		Dependencies: []string{
-			"pagerduty_team",
-			"pagerduty_user",
+			"pagerduty_service",
 		},
 	})
 }

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -15,9 +15,8 @@ import (
 
 func init() {
 	resource.AddTestSweepers("pagerduty_schedule", &resource.Sweeper{
-		Name:         "pagerduty_schedule",
-		F:            testSweepSchedule,
-		Dependencies: []string{"pagerduty_user"},
+		Name: "pagerduty_schedule",
+		F:    testSweepSchedule,
 	})
 }
 

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -16,10 +16,6 @@ func init() {
 	resource.AddTestSweepers("pagerduty_service", &resource.Sweeper{
 		Name: "pagerduty_service",
 		F:    testSweepService,
-		Dependencies: []string{
-			"pagerduty_escalation_policy",
-			"pagerduty_user",
-		},
 	})
 }
 

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -14,9 +14,13 @@ import (
 
 func init() {
 	resource.AddTestSweepers("pagerduty_user", &resource.Sweeper{
-		Name:         "pagerduty_user",
-		F:            testSweepUser,
-		Dependencies: []string{"pagerduty_team"},
+		Name: "pagerduty_user",
+		F:    testSweepUser,
+		Dependencies: []string{
+			"pagerduty_team",
+			"pagerduty_schedule",
+			"pagerduty_escalation_policy",
+		},
 	})
 }
 


### PR DESCRIPTION
Resources were previously not swept in the right order and I kept seeing dangling users after failed runs. This fixes it.