### PR TITLE
tests: Fix names of escalation policies

### DIFF
--- a/pagerduty/resource_pagerduty_extension_test.go
+++ b/pagerduty/resource_pagerduty_extension_test.go
@@ -47,9 +47,9 @@ func testSweepExtension(region string) error {
 }
 
 func TestAccPagerDutyExtension_Basic(t *testing.T) {
-	extension_name := resource.PrefixedUniqueId("tf")
-	extension_name_updated := resource.PrefixedUniqueId("tf")
-	name := resource.PrefixedUniqueId("tf")
+	extension_name := resource.PrefixedUniqueId("tf-")
+	extension_name_updated := resource.PrefixedUniqueId("tf-")
+	name := resource.PrefixedUniqueId("tf-")
 	url := "https://example.com/recieve_a_pagerduty_webhook"
 	url_updated := "https://example.com/webhook_foo"
 


### PR DESCRIPTION
Some escalation policies aren't being swept as these have different name than sweepers expect.