### PR TITLE
tests: Change phone number to non-premium + fix team sweeper

### DIFF
--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -16,6 +16,11 @@ func init() {
 	resource.AddTestSweepers("pagerduty_team", &resource.Sweeper{
 		Name: "pagerduty_team",
 		F:    testSweepTeam,
+		Dependencies: []string{
+			"pagerduty_escalation_policy",
+			"pagerduty_service",
+			"pagerduty_schedule",
+		},
 	})
 }
 

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -208,7 +208,7 @@ resource "pagerduty_user_contact_method" "foo" {
   user_id      = "${pagerduty_user.foo.id}"
   type         = "sms_contact_method"
   country_code = "+1"
-  address      = "2025550199"
+  address      = "8448003889"
   label        = "%[1]v"
 }
 `, username, email)
@@ -229,7 +229,7 @@ resource "pagerduty_user_contact_method" "foo" {
   user_id      = "${pagerduty_user.foo.id}"
   type         = "sms_contact_method"
   country_code = "+1"
-  address      = "2025550104"
+  address      = "6509892965"
   label        = "%[1]v"
 }
 `, username, email)


### PR DESCRIPTION
This fixes the last continuously failing test.

```
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- FAIL: TestAccPagerDutyUserContactMethodSMS_Basic (5.03s)
    testing.go:459: Step 0 error: Error applying: 1 error(s) occurred:
        
        * pagerduty_user_contact_method.foo: 1 error(s) occurred:
        
        * pagerduty_user_contact_method.foo: POST API call to https://api.pagerduty.com/users/P3QTWPO/contact_methods failed 400 Bad Request. Code: 2001, Errors: [Phone number Premium-rate numbers are not supported], Message: Invalid Input Provided
```

Phone numbers used are just PagerDuty's own sales numbers from https://www.pagerduty.com/contact-us/ 😜 

----

Secondly I'm setting sweeper dependencies correctly to address the following failure:

> 2019/03/14 17:11:56 [ERR] error running (pagerduty_team): DELETE API call to https://api.pagerduty.com/teams/P608YDA failed 400 Bad Request. Code: 6006, Errors: [Cannot delete team with existing associations; associations could be Escalation Policies, Services, Schedules or Subteams], Message: Team has existing associations

