### PR TITLE
r/pagerduty_user: set invintation_sent

### DIFF
--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -161,6 +161,7 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", user.Description)
 	d.Set("job_title", user.JobTitle)
 	d.Set("teams", user.Teams)
+	d.Set("invitation_sent", user.InvitationSent)
 
 	return nil
 }


### PR DESCRIPTION
While working on #126 and running acceptance tests with new SDK I discovered this bug:
```
make testacc TEST=./pagerduty TESTARGS='-run=TestAccPagerDutyUser_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./pagerduty -v -run=TestAccPagerDutyUser_import -timeout 120m
=== RUN   TestAccPagerDutyUser_import
--- FAIL: TestAccPagerDutyUser_import (10.70s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }


        (map[string]string) (len=1) {
         (string) (len=15) "invitation_sent": (string) (len=5) "false"
        }

```