### PR TITLE
r/pagerduty_service: test syntax for sdk 0.12

### DIFF
--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -690,19 +690,19 @@ resource "pagerduty_service" "foo" {
 		}
 	}
 
-	support_hours = [{
+	support_hours {
 		type         = "fixed_time_per_day"
 		time_zone    = "America/Lima"
 		start_time   = "09:00:00"
 		end_time     = "17:00:00"
 		days_of_week = [ 1, 2, 3, 4, 5 ]
-	}]
+	}
 
 	scheduled_actions {
 		type = "urgency_change"
 		to_urgency = "high"
 		at {
-			type = "named_time",
+			type = "named_time"
 			name = "support_hours_start"
 		}
 	}
@@ -755,13 +755,13 @@ resource "pagerduty_service" "foo" {
 		}
 	}
 
-	support_hours = [{
+	support_hours {
 		type         = "fixed_time_per_day"
 		time_zone    = "America/Lima"
 		start_time   = "09:00:00"
 		end_time     = "17:00:00"
 		days_of_week = [ 1, 2, 3, 4, 5 ]
-	}]
+	}
 }
 `, username, email, escalationPolicy, service)
 }
@@ -810,19 +810,19 @@ resource "pagerduty_service" "foo" {
 		}
 	}
 
-	support_hours = [{
+	support_hours {
 		type         = "fixed_time_per_day"
 		time_zone    = "America/Lima"
 		start_time   = "09:00:00"
 		end_time     = "17:00:00"
 		days_of_week = [ 1, 2, 3, 4, 5 ]
-	}]
+	}
 
 	scheduled_actions {
 		type = "urgency_change"
 		to_urgency = "high"
 		at {
-			type = "named_time",
+			type = "named_time"
 			name = "support_hours_start"
 		}
 	}


### PR DESCRIPTION
Tests for `pagerduty_service` in fixture configurations have some tricks that are possible in terraform <=0.12 but will be failing with new sdk with errors like:
```
--- FAIL: TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules (7.81s)
    testing.go:568: Step 1 error: /var/folders/z1/192_t7995nj8knv0qyj7krxm0000gn/T/tf-test957521905/main.tf:56,23-24: Unexpected comma after argument; Argument definitions must be separated by newlines, not commas. An argument definition must end with a newline.
```