### PR TITLE
r/pagerduty_escalation_policy: correctly set teams

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -125,9 +126,12 @@ func resourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.Set("name", escalationPolicy.Name)
-	d.Set("teams", escalationPolicy.Teams)
 	d.Set("description", escalationPolicy.Description)
 	d.Set("num_loops", escalationPolicy.NumLoops)
+
+	if err := d.Set("teams", flattenTeams(escalationPolicy.Teams)); err != nil {
+		return fmt.Errorf("error setting teams: %s", err)
+	}
 
 	if err := d.Set("rule", flattenEscalationRules(escalationPolicy.EscalationRules)); err != nil {
 		return err
@@ -225,4 +229,13 @@ func expandTeams(v interface{}) []*pagerduty.TeamReference {
 	}
 
 	return teams
+}
+
+func flattenTeams(teams []*pagerduty.TeamReference) []string {
+	res := make([]string, len(teams))
+	for i, t := range teams {
+		res[i] = t.ID
+	}
+
+	return res
 }


### PR DESCRIPTION
While working on #126 I've discovered this error:
```
make testacc TEST=./pagerduty TESTARGS='-run=TestAccPagerDutyEscalationPolicyWithTeams_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./pagerduty -v -run=TestAccPagerDutyEscalationPolicyWithTeams_Basic -timeout 120m
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
--- FAIL: TestAccPagerDutyEscalationPolicyWithTeams_Basic (19.53s)
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: DELETE API call to https://api.pagerduty.com/teams/P3NAB0C failed 400 Bad Request. Code: 6006, Errors: [Cannot delete team with existing associations; associations could be Escalation Policies, Services, Schedules or Subteams], Message: Team has existing associations

        State: pagerduty_team.foo:
          ID = P3NAB0C
          provider = provider.pagerduty
          description = foo
          name = tf-xog7u
FAIL
FAIL	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	19.562s
make: *** [testacc] Error 1
```

Teams attribute was not correctly set on read and underlying pagerduty sdk was not actually removing teams from policy. So terraform was trying to remove both resources in parallel.

This fix depends on fix in pagerduty go library https://github.com/heimweh/go-pagerduty/pull/25


<details><summary>Acceptance tests after fix:</summary>
<p>

```
→ GOFLAGS=-mod=vendor make testacc TEST=./pagerduty TESTARGS='-run=TestAccPagerDutyEscalationPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./pagerduty -v -run=TestAccPagerDutyEscalationPolicy -timeout 120m
=== RUN   TestAccPagerDutyEscalationPolicy_import
--- PASS: TestAccPagerDutyEscalationPolicy_import (14.44s)
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (20.58s)
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
--- PASS: TestAccPagerDutyEscalationPolicyWithTeams_Basic (21.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	56.243s
```

</p>
</details>