### PR TITLE
Remove status as it is not required

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -189,7 +189,6 @@ func resourcePagerDutyService() *schema.Resource {
 func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 	service := pagerduty.Service{
 		Name:   d.Get("name").(string),
-		Status: d.Get("status").(string),
 	}
 
 	if attr, ok := d.GetOk("description"); ok {
@@ -276,6 +275,7 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("name", service.Name)
+	d.Set("status", service.Status)
 	d.Set("created_at", service.CreatedAt)
 	d.Set("escalation_policy", service.EscalationPolicy.ID)
 	d.Set("description", service.Description)

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -188,7 +188,7 @@ func resourcePagerDutyService() *schema.Resource {
 
 func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 	service := pagerduty.Service{
-		Name:   d.Get("name").(string),
+		Name: d.Get("name").(string),
 	}
 
 	if attr, ok := d.GetOk("description"); ok {

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -276,7 +276,6 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("name", service.Name)
-	d.Set("status", service.Status)
 	d.Set("created_at", service.CreatedAt)
 	d.Set("escalation_policy", service.EscalationPolicy.ID)
 	d.Set("description", service.Description)


### PR DESCRIPTION
If service status is "warning" or "critical" Pagerduty API will reject as it only accepts "active" or "disabled".

Having the Status as part of the payload will make cause the apply to fail if either "warning" or "critical" status. However not having it as part of the payload makes the Pagerduty accept the changes.