### PR TITLE
Remove invalid role types

### DIFF
--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -37,13 +37,6 @@ func resourcePagerDutyUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "user",
-				ValidateFunc: validateValueFunc([]string{
-					"admin",
-					"limited_user",
-					"read_only_user",
-					"observer",
-					"user",
-				}),
 			},
 
 			"job_title": {

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -40,9 +40,8 @@ func resourcePagerDutyUser() *schema.Resource {
 				ValidateFunc: validateValueFunc([]string{
 					"admin",
 					"limited_user",
-					"owner",
 					"read_only_user",
-					"team_responder",
+					"observer",
 					"user",
 				}),
 			},
@@ -106,12 +105,7 @@ func buildUserStruct(d *schema.ResourceData) *pagerduty.User {
 	}
 
 	if attr, ok := d.GetOk("role"); ok {
-		role := attr.(string)
-		// Skip setting the role if the user is the owner of the account.
-		// Can't change this through the API.
-		if role != "owner" {
-			user.Role = role
-		}
+		user.Role = attr.(string)
 	}
 
 	if attr, ok := d.GetOk("job_title"); ok {

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -92,7 +92,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "red"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "role", "team_responder"),
+						"pagerduty_user.foo", "role", "observer"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "job_title", "bar"),
 					resource.TestCheckResourceAttr(
@@ -213,7 +213,7 @@ resource "pagerduty_user" "foo" {
   name        = "%s"
   email       = "%s"
   color       = "red"
-  role        = "team_responder"
+  role        = "observer"
   job_title   = "bar"
   description = "bar"
   time_zone   = "Europe/Dublin"


### PR DESCRIPTION
According to [the documentation](https://support.pagerduty.com/docs/advanced-permissions#section-base-roles), pagerduty no longer supports the `team_responder` role. It was replaced by the `observer` role. This creates a constant diff when running terraform since the request is issued with the legacy type but pagerduty will internally convert it to the new type.

I have also removed the owner role from the validation function as it was being ignored by the provider anyway and not sent with the request to the Pagerduty API, causing constant diffs on that role as well.