### PR TITLE
Fix issues with user's teams not set properly and update user's roles

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -81,6 +81,7 @@ func testAccCheckPagerDutyTeamMembershipConfig(user, team string) string {
 resource "pagerduty_user" "foo" {
   name = "%[1]v"
   email = "%[1]v@foo.com"
+  teams = ["${pagerduty_team.foo.id}"]
 }
 
 resource "pagerduty_team" "foo" {

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -43,7 +43,7 @@ func resourcePagerDutyUser() *schema.Resource {
 					"limited_user",
 					"owner",
 					"read_only_user",
-					"team_responder",
+					"observer",
 					"user",
 				}),
 			},

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -160,7 +161,11 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("avatar_url", user.AvatarURL)
 	d.Set("description", user.Description)
 	d.Set("job_title", user.JobTitle)
-	d.Set("teams", user.Teams)
+
+	if err := d.Set("teams", flattenTeams(user.Teams)); err != nil {
+		return fmt.Errorf("error setting teams: %s", err)
+	}
+
 	d.Set("invitation_sent", user.InvitationSent)
 
 	return nil

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -92,7 +92,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "red"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "role", "team_responder"),
+						"pagerduty_user.foo", "role", "observer"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "job_title", "bar"),
 					resource.TestCheckResourceAttr(
@@ -213,7 +213,7 @@ resource "pagerduty_user" "foo" {
   name        = "%s"
   email       = "%s"
   color       = "red"
-  role        = "team_responder"
+  role        = "observer"
   job_title   = "bar"
   description = "bar"
   time_zone   = "Europe/Dublin"


### PR DESCRIPTION
This PR fixes 2 issues:

1. Teams in the user's resource not set properly, related to #129 
2. Fix acceptance tests not passing because of updated list of user roles

### Acceptance test

1.
```
TF_ACC=1 go test -run TestAccPagerDutyUser_Basic ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (18.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   18.468s
```

2.
```
TF_ACC=1 go test -run TestAccPagerDutyTeamMembership_Basic ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (16.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   16.746s
```

### Step to reproduce the issue:

1.
#### Using terraform
Example HCL

```
resource "pagerduty_user" "foo" {
  name = "Foo"
  email = "foo@foo.com"
  teams = ["${pagerduty_team.foo.id}"]
}

resource "pagerduty_team" "foo" {
  name        = "Foo"
  description = "foo"
}
```

Setup user and team in Pagerduty based on the configuration from the HCL above.
Import the terraform HCL above with terraform import
Doing a terraform plan now shows a difference where the team information was not imported