### PR TITLE
resource/pagerduty_maintenance_window: Allow services to be unordered

### DIFF
--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -31,9 +31,10 @@ func resourcePagerDutyMaintenanceWindow() *schema.Resource {
 			},
 
 			"services": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 
 			"description": {
@@ -49,7 +50,7 @@ func buildMaintenanceWindowStruct(d *schema.ResourceData) *pagerduty.Maintenance
 	window := &pagerduty.MaintenanceWindow{
 		StartTime: d.Get("start_time").(string),
 		EndTime:   d.Get("end_time").(string),
-		Services:  expandServices(d.Get("services")),
+		Services:  expandServices(d.Get("services").(*schema.Set)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -125,10 +126,10 @@ func resourcePagerDutyMaintenanceWindowDelete(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func expandServices(v interface{}) []*pagerduty.ServiceReference {
+func expandServices(v *schema.Set) []*pagerduty.ServiceReference {
 	var services []*pagerduty.ServiceReference
 
-	for _, srv := range v.([]interface{}) {
+	for _, srv := range v.List() {
 		service := &pagerduty.ServiceReference{
 			Type: "service_reference",
 			ID:   srv.(string),
@@ -139,12 +140,12 @@ func expandServices(v interface{}) []*pagerduty.ServiceReference {
 	return services
 }
 
-func flattenServices(v []*pagerduty.ServiceReference) []interface{} {
+func flattenServices(v []*pagerduty.ServiceReference) *schema.Set {
 	var services []interface{}
 
 	for _, srv := range v {
 		services = append(services, srv.ID)
 	}
 
-	return services
+	return schema.NewSet(schema.HashString, services)
 }

--- a/pagerduty/resource_pagerduty_maintenance_window_test.go
+++ b/pagerduty/resource_pagerduty_maintenance_window_test.go
@@ -198,11 +198,24 @@ resource "pagerduty_service" "foo" {
   }
 }
 
+resource "pagerduty_service" "foo2" {
+  name                    = "%[1]v2"
+  description             = "foo2"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
 resource "pagerduty_maintenance_window" "foo" {
   description = "%[1]v"
   start_time  = "%[2]v"
   end_time    = "%[3]v"
-  services    = ["${pagerduty_service.foo.id}"]
+  services    = ["${pagerduty_service.foo.id}", "${pagerduty_service.foo2.id}"]
 }
 `, desc, start, end)
 }


### PR DESCRIPTION
This PR changes the type for `services` from `TypeList` to `TypeSet`. 
Fixes the following issue: https://github.com/terraform-providers/terraform-provider-pagerduty/issues/137 by allowing us to pass an unordered list of services.