### PR TITLE
resource/pagerduty_user: teams may be computed

### DIFF
--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -52,6 +52,7 @@ func resourcePagerDutyUser() *schema.Resource {
 
 			"teams": {
 				Type:     schema.TypeSet,
+				Computed: true,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
This PR allows the field `teams` to also be computed. 
This is because users may inherit a team membership through an escalation policy. 

This also fixes a diff issue in a test (TestAccPagerDutyEscalationPolicyWithTeams_Basic)