### PR TITLE
resource/pagerduty_user: deprecate teams attribute

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -81,7 +81,6 @@ func testAccCheckPagerDutyTeamMembershipConfig(user, team string) string {
 resource "pagerduty_user" "foo" {
   name = "%[1]v"
   email = "%[1]v@foo.com"
-  teams = ["${pagerduty_team.foo.id}"]
 }
 
 resource "pagerduty_team" "foo" {

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -51,8 +51,10 @@ func resourcePagerDutyUser() *schema.Resource {
 			},
 
 			"teams": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Deprecated: "Use the 'pagerduty_team_membership' resource instead.",
+				Computed:   true,
+				Optional:   true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -122,8 +122,6 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "email", email),
-					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "teams.#", "1"),
 				),
 			},
 			{
@@ -134,8 +132,6 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "email", email),
-					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "teams.#", "2"),
 				),
 			},
 			{
@@ -146,8 +142,6 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "email", email),
-					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "teams.#", "0"),
 				),
 			},
 		},
@@ -229,7 +223,11 @@ resource "pagerduty_team" "foo" {
 resource "pagerduty_user" "foo" {
   name  = "%s"
   email = "%s"
-  teams = ["${pagerduty_team.foo.id}"]
+}
+
+resource "pagerduty_team_membership" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  team_id = "${pagerduty_team.foo.id}"
 }
 `, team, username, email)
 }
@@ -247,7 +245,16 @@ resource "pagerduty_team" "bar" {
 resource "pagerduty_user" "foo" {
   name  = "%s"
   email = "%s"
-  teams = ["${pagerduty_team.foo.id}", "${pagerduty_team.bar.id}"]
+}
+
+resource "pagerduty_team_membership" "foo" {
+  user_id = "${pagerduty_user.foo.id}"
+  team_id = "${pagerduty_team.foo.id}"
+}
+
+resource "pagerduty_team_membership" "bar" {
+  user_id = "${pagerduty_user.foo.id}"
+  team_id = "${pagerduty_team.bar.id}"
 }
 `, team1, team2, username, email)
 }

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
   * `color` - (Optional) The schedule color for the user. Valid options are blue, brown, cayenne, chocolate, crimson, cyan, dark, darkolive, deep, firebrick, forest, goldenrod, gray, green, grey, grey20, indigo, lime, magenta, maroon, medium, midnight, olive, olivedrab, orange, orchid, pink, purple, red, royal, saddle, sea, slate, steel, teal, turquoise or violet.
   * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `owner`, `read_only_user`, `team_responder` or `user`
   * `job_title` - (Optional) The user's title.
-  * `teams` - (Optional) A list of teams the user should belong to.
+  * `teams` - (Optional, **DEPRECATED**) A list of teams the user should belong to. Please use `pagerduty_team_membership` instead.
   * `description` - (Optional) A human-friendly description of the user.
     If not set, a placeholder of "Managed by Terraform" will be set.
 


### PR DESCRIPTION
Here we're deprecating the `teams` attribute.
Teams can be added/removed using the dedicated resource `pagerduty_team_membership`.

This attribute has been quite tricky to maintain and is causing a lot of weird dependency conflicts and failing tests. In fact, team membership can be inherited from an escalation policy causing issues with this attribute. 

Relates #147

This change is also more in line with the PagerDuty API.

Before:

```hcl
resource "pagerduty_team" "foo" {
  name = "foo"
}

resource "pagerduty_user" "foo" {
  name  = "foo"
  email = "foo@foo.com"
  teams = ["${pagerduty_team.foo.id}"]
}
```

After:
```hcl
resource "pagerduty_team" "foo" {
  name = "foo"
}

resource "pagerduty_user" "foo" {
  name  = "foo"
  email = "foo@foo.com"
}

resource "pagerduty_team_membership" "foo" {
  user_id = "${pagerduty_user.foo.id}"
  team_id = "${pagerduty_team.foo.id}"
}
```