### PR TITLE
resource/pagerduty_team_membership: Retry create on error

### DIFF
--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -54,8 +54,16 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
+func isErrCode(err error, code int) bool {
+	if e, ok := err.(*pagerduty.Error); ok && e.ErrorResponse.StatusCode == code {
+		return true
+	}
+
+	return false
+}
+
 func handleNotFoundError(err error, d *schema.ResourceData) error {
-	if perr, ok := err.(*pagerduty.Error); ok && perr.ErrorResponse.StatusCode == 404 {
+	if isErrCode(err, 404) {
 		log.Printf("[WARN] Removing %s because it's gone", d.Id())
 		d.SetId("")
 		return nil


### PR DESCRIPTION
This is to address a flaky test failure where a newly created PagerDuty user fails to get added to a newly created team.