### PR TITLE
resource/resource_pagerduty_service: skip tests if missing ability

### DIFF
--- a/pagerduty/provider_test.go
+++ b/pagerduty/provider_test.go
@@ -64,3 +64,22 @@ func timeNowInAccLoc() time.Time {
 
 	return timeNowInLoc(name)
 }
+
+func testAccPreCheckPagerDutyAbility(t *testing.T, ability string) {
+	if v := os.Getenv("PAGERDUTY_TOKEN"); v == "" {
+		t.Fatal("PAGERDUTY_TOKEN must be set for acceptance tests")
+	}
+
+	config := &Config{
+		Token: os.Getenv("PAGERDUTY_TOKEN"),
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.Abilities.Test(ability); err != nil {
+		t.Skipf("Missing ability: %s. Skipping test", ability)
+	}
+}

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -132,7 +132,7 @@ func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckPagerDutyAbility(t, "preview_intelligent_alert_grouping") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
This skips the alert grouping tests (TestAccPagerDutyService_AlertGrouping) if the account is missing the ability.