### PR TITLE
Adding 'depends_on' argument to Event Rules Doc

### DIFF
--- a/website/docs/r/event_rule.html.markdown
+++ b/website/docs/r/event_rule.html.markdown
@@ -14,8 +14,8 @@ An [event rule](https://v2.developer.pagerduty.com/docs/global-event-rules-api) 
 ## Example Usage
 
 ```hcl
-variable "action_list" {
-    default = [
+resource "pagerduty_event_rule" "second" {
+    action_json = jsonencode([
         [
             "route",
             "P5DTL0K"
@@ -26,41 +26,59 @@ variable "action_list" {
         ],
         [
             "annotate",
-            "Managed by terraform"
+            "2 Managed by terraform"
         ],
         [
             "priority",
             "PL451DT"
         ]
-    ]
-}
-variable "condition_list" {
-    default = [
+    ])
+    condition_json = jsonencode([
         "and",
         ["contains",["path","payload","source"],"website"],
         ["contains",["path","headers","from","0","address"],"homer"]
-    ]
+    ])
+    advanced_condition_json = jsonencode([
+        [
+            "scheduled-weekly",
+            1565392127032,
+            3600000,
+            "America/Los_Angeles",
+            [
+                1,
+                2,
+                3,
+                5,
+                7
+            ]
+        ]
+    ])
 }
-variable "advanced_condition_list" {
-    default = [
-      [
-          "scheduled-weekly",
-          1565392127032,
-          3600000,
-          "America/Los_Angeles",
-          [
-              1,
-              3,
-              5,
-              7
-          ]
-      ]
-    ]
-}
-resource "pagerduty_event_rule" "example" {
-    action_json = jsonencode(var.action_list)
-    condition_json = jsonencode(var.condition_list)
-    advanced_condition_json = jsonencode(var.advanced_condition_list)
+resource "pagerduty_event_rule" "third" {
+    action_json = jsonencode([
+        [
+            "route",
+            "P5DTL0K"
+        ],
+        [
+            "severity",
+            "warning"
+        ],
+        [
+            "annotate",
+            "3 Managed by terraform"
+        ],
+        [
+            "priority",
+            "PL451DT"
+        ]
+    ])
+    condition_json = jsonencode([
+        "and",
+        ["contains",["path","payload","source"],"website"],
+        ["contains",["path","headers","from","0","address"],"homer"]
+    ])
+    depends_on = [pagerduty_event_rule.two]
 }
 ```
 
@@ -72,6 +90,7 @@ The following arguments are supported:
 * `condition_json` - (Required) Contains a list of conditions. The first field in the list is `and` or `or`, followed by a list of operators and values.
 * `advanced_condition_json` - (Required) Contains a list of specific conditions including `active-between`,`scheduled-weekly`, and `frequency-over`. The first element in the list is the label for the condition, followed by a list of values for the specific condition. For more details on these conditions see [Advanced Condition](https://v2.developer.pagerduty.com/docs/global-event-rules-api#section-advanced-condition) in the PagerDuty API documentation.
 * `catch_all` - (Optional) A boolean that indicates whether the rule is a catch all for the account. 
+* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order.
 
 ## Attributes Reference
 

--- a/website/docs/r/event_rule.html.markdown
+++ b/website/docs/r/event_rule.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 * `condition_json` - (Required) Contains a list of conditions. The first field in the list is `and` or `or`, followed by a list of operators and values.
 * `advanced_condition_json` - (Required) Contains a list of specific conditions including `active-between`,`scheduled-weekly`, and `frequency-over`. The first element in the list is the label for the condition, followed by a list of values for the specific condition. For more details on these conditions see [Advanced Condition](https://v2.developer.pagerduty.com/docs/global-event-rules-api#section-advanced-condition) in the PagerDuty API documentation.
 * `catch_all` - (Optional) A boolean that indicates whether the rule is a catch all for the account. 
-* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order.
+* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order. `depends_on` ensures that  the rules are created in the order specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Creating Event Rules in order is important. Using the `depends_on` argument allows rule order to be specified. This update explains that in the Event Rules documentation. 