### PR TITLE
Handle missing user referenced by team membership

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -70,7 +70,7 @@ func resourcePagerDutyTeamMembershipRead(d *schema.ResourceData, meta interface{
 
 	user, _, err := client.Users.Get(userID, &pagerduty.GetUserOptions{})
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	if !isTeamMember(user, teamID) {


### PR DESCRIPTION
Same as https://github.com/terraform-providers/terraform-provider-pagerduty/pull/30 but for team membership.

Without this change, if a user is deleted from Pagerduty, refreshing a team membership fails with the following message:

```
Error: GET API call to https://api.pagerduty.com/users/PWR**** failed 404 Not Found. Code: 2100, Errors: <nil>, Message: Not Found
```