### PR TITLE
Fixing issue with perpetual diff in event rules 

### DIFF
--- a/pagerduty/resource_pagerduty_event_rule.go
+++ b/pagerduty/resource_pagerduty_event_rule.go
@@ -79,7 +79,7 @@ func resourcePagerDutyEventRuleCreate(d *schema.ResourceData, meta interface{}) 
 
 	eventRule := buildEventRuleStruct(d)
 
-	log.Printf("[INFO] Creating PagerDuty event rule: %s", "eventRule")
+	log.Printf("[INFO] Creating PagerDuty event rule: %s", eventRule.Condition)
 
 	eventRule, _, err := client.EventRules.Create(eventRule)
 	if err != nil {
@@ -117,9 +117,10 @@ func resourcePagerDutyEventRuleRead(d *schema.ResourceData, meta interface{}) er
 	// if event rule is found set to ResourceData
 	d.Set("action_json", flattenSlice(foundRule.Actions))
 	d.Set("condition_json", flattenSlice(foundRule.Condition))
-	d.Set("advanced_condition_json", flattenSlice(foundRule.AdvancedCondition))
+	if foundRule.AdvancedCondition != nil {
+		d.Set("advanced_condition_json", flattenSlice(foundRule.AdvancedCondition))
+	}
 	d.Set("catch_all", foundRule.CatchAll)
-
 	return nil
 }
 func resourcePagerDutyEventRuleUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/pagerduty/resource_pagerduty_event_rule_test.go
+++ b/pagerduty/resource_pagerduty_event_rule_test.go
@@ -62,14 +62,15 @@ func TestAccPagerDutyEventRule_Basic(t *testing.T) {
 			{
 				Config: testAccCheckPagerDutyEventRuleConfig(eventRule),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventRuleExists("pagerduty_event_rule.first"),
+					testAccCheckPagerDutyEventRuleExists("pagerduty_event_rule.foo"),
 				),
 			},
 
 			{
 				Config: testAccCheckPagerDutyEventRuleConfigUpdated(eventRuleUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventRuleExists("pagerduty_event_rule.foo_resource_updated"),
+					testAccCheckPagerDutyEventRuleExists("pagerduty_event_rule.foo-update"),
+					resource.TestCheckNoResourceAttr("pagerduty_event_rule.foo-update", "advanced_condition_json"),
 				),
 			},
 		},
@@ -103,7 +104,7 @@ func testAccCheckPagerDutyEventRuleExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Escalation Policy ID is set")
+			return fmt.Errorf("No Event Rule ID is set")
 		}
 
 		client := testAccProvider.Meta().(*pagerduty.Client)
@@ -123,7 +124,7 @@ func testAccCheckPagerDutyEventRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Escalation policy not found: %v - %v", rs.Primary.ID, found)
+			return fmt.Errorf("Event rule not found: %v - %v", rs.Primary.ID, found)
 		}
 
 		return nil
@@ -132,64 +133,32 @@ func testAccCheckPagerDutyEventRuleExists(n string) resource.TestCheckFunc {
 
 func testAccCheckPagerDutyEventRuleConfig(eventRule string) string {
 	return fmt.Sprintf(`
-variable "action_list" {
-	default = [["route","P5DTL0K"],["severity","warning"],["annotate","%s"],["priority","PL451DT"]]
-}
-variable "condition_list" {
-	default = ["and",["contains",["path","payload","source"],"website"]]
-}
-variable "advanced_condition_list" {
-    default = [
-                [
-                    "scheduled-weekly",
-                    1565392127032,
-                    3600000,
-                    "America/Los_Angeles",
-                    [
-                        1,
-                        3,
-                        5,
-                        7
-                    ]
-                ]
-	]
-}
-resource "pagerduty_event_rule" "first" {
-	action_json = jsonencode(var.action_list)
-	condition_json = jsonencode(var.condition_list)
-	advanced_condition_json = jsonencode(var.advanced_condition_list)
+resource "pagerduty_event_rule" "foo" {
+	action_json = jsonencode([["route","P5DTL0K"],["severity","warning"],["annotate","%s"],["priority","PL451DT"]])
+	condition_json = jsonencode(["and",["contains",["path","payload","source"],"website"]])
+	advanced_condition_json = jsonencode([
+		[
+			"scheduled-weekly",
+			1565392127032,
+			3600000,
+			"America/Los_Angeles",
+			[
+				1,
+				3,
+				5,
+				7
+			]
+		]
+	])
 }
 `, eventRule)
 }
 
 func testAccCheckPagerDutyEventRuleConfigUpdated(eventRule string) string {
 	return fmt.Sprintf(`
-variable "action_list" {
-	default = [["route","P5DTL0K"],["severity","warning"],["annotate","%s"],["priority","PL451DT"]]
-}
-variable "condition_list" {
-	default = ["and",["contains",["path","payload","source"],"website"],["contains",["path","headers","from","0","address"],"homer"]]
-}
-variable "advanced_condition_list" {
-    default = [
-                [
-                    "scheduled-weekly",
-                    1565392127032,
-                    3600000,
-                    "America/Los_Angeles",
-                    [
-                        1,
-                        3,
-                        5,
-                        7
-                    ]
-                ]
-	]
-}
-resource "pagerduty_event_rule" "foo_resource_updated" {
-	action_json = jsonencode(var.action_list)
-	condition_json = jsonencode(var.condition_list)
-	advanced_condition_json = jsonencode(var.advanced_condition_list)
+resource "pagerduty_event_rule" "foo-update" {
+	action_json = jsonencode([["route","P5DTL0K"],["severity","warning"],["annotate","%s"],["priority","PL451DT"]])
+	condition_json = jsonencode(["and",["contains",["path","payload","source"],"website"]])
 }
 `, eventRule)
 }

--- a/website/docs/r/event_rule.html.markdown
+++ b/website/docs/r/event_rule.html.markdown
@@ -14,8 +14,8 @@ An [event rule](https://v2.developer.pagerduty.com/docs/global-event-rules-api) 
 ## Example Usage
 
 ```hcl
-variable "action_list" {
-    default = [
+resource "pagerduty_event_rule" "second" {
+    action_json = jsonencode([
         [
             "route",
             "P5DTL0K"
@@ -26,41 +26,59 @@ variable "action_list" {
         ],
         [
             "annotate",
-            "Managed by terraform"
+            "2 Managed by terraform"
         ],
         [
             "priority",
             "PL451DT"
         ]
-    ]
-}
-variable "condition_list" {
-    default = [
+    ])
+    condition_json = jsonencode([
         "and",
         ["contains",["path","payload","source"],"website"],
         ["contains",["path","headers","from","0","address"],"homer"]
-    ]
+    ])
+    advanced_condition_json = jsonencode([
+        [
+            "scheduled-weekly",
+            1565392127032,
+            3600000,
+            "America/Los_Angeles",
+            [
+                1,
+                2,
+                3,
+                5,
+                7
+            ]
+        ]
+    ])
 }
-variable "advanced_condition_list" {
-    default = [
-      [
-          "scheduled-weekly",
-          1565392127032,
-          3600000,
-          "America/Los_Angeles",
-          [
-              1,
-              3,
-              5,
-              7
-          ]
-      ]
-    ]
-}
-resource "pagerduty_event_rule" "example" {
-    action_json = jsonencode(var.action_list)
-    condition_json = jsonencode(var.condition_list)
-    advanced_condition_json = jsonencode(var.advanced_condition_list)
+resource "pagerduty_event_rule" "third" {
+    action_json = jsonencode([
+        [
+            "route",
+            "P5DTL0K"
+        ],
+        [
+            "severity",
+            "warning"
+        ],
+        [
+            "annotate",
+            "3 Managed by terraform"
+        ],
+        [
+            "priority",
+            "PL451DT"
+        ]
+    ])
+    condition_json = jsonencode([
+        "and",
+        ["contains",["path","payload","source"],"website"],
+        ["contains",["path","headers","from","0","address"],"homer"]
+    ])
+    depends_on = [pagerduty_event_rule.two]
 }
 ```
 
@@ -72,6 +90,7 @@ The following arguments are supported:
 * `condition_json` - (Required) Contains a list of conditions. The first field in the list is `and` or `or`, followed by a list of operators and values.
 * `advanced_condition_json` - (Required) Contains a list of specific conditions including `active-between`,`scheduled-weekly`, and `frequency-over`. The first element in the list is the label for the condition, followed by a list of values for the specific condition. For more details on these conditions see [Advanced Condition](https://v2.developer.pagerduty.com/docs/global-event-rules-api#section-advanced-condition) in the PagerDuty API documentation.
 * `catch_all` - (Optional) A boolean that indicates whether the rule is a catch all for the account. 
+* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order.
 
 ## Attributes Reference
 

--- a/website/docs/r/event_rule.html.markdown
+++ b/website/docs/r/event_rule.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 * `condition_json` - (Required) Contains a list of conditions. The first field in the list is `and` or `or`, followed by a list of operators and values.
 * `advanced_condition_json` - (Required) Contains a list of specific conditions including `active-between`,`scheduled-weekly`, and `frequency-over`. The first element in the list is the label for the condition, followed by a list of values for the specific condition. For more details on these conditions see [Advanced Condition](https://v2.developer.pagerduty.com/docs/global-event-rules-api#section-advanced-condition) in the PagerDuty API documentation.
 * `catch_all` - (Optional) A boolean that indicates whether the rule is a catch all for the account. 
-* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order.
+* `depends_on` - (Optional) A [Terraform meta-parameter](https://www.terraform.io/docs/configuration-0-11/resources.html#depends_on) that ensures that the `event_rule` specified is created before the current rule. This is important because Event Rules in PagerDuty are executed in order. `depends_on` ensures that  the rules are created in the order specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This addresses [Issue 155](https://github.com/terraform-providers/terraform-provider-pagerduty/issues/155)

Test output.


```
TF_ACC=1 go test -run "TestAccPagerDutyEventRule_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyEventRule_Basic
--- PASS: TestAccPagerDutyEventRule_Basic (11.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	11.934s
```