### PR TITLE
Add html_url read-only attribute to pagerduty_service and fixes for others

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -27,6 +27,10 @@ func resourcePagerDutyExtension() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -106,6 +110,7 @@ func resourcePagerDutyExtensionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("summary", extension.Summary)
 	d.Set("name", extension.Name)
 	d.Set("endpoint_url", extension.EndpointURL)
+	d.Set("html_url", extension.HTMLURL)
 	if err := d.Set("extension_objects", flattenExtensionObjects(extension.ExtensionObjects)); err != nil {
 		log.Printf("[WARN] error setting extension_objects: %s", err)
 	}

--- a/pagerduty/resource_pagerduty_extension_test.go
+++ b/pagerduty/resource_pagerduty_extension_test.go
@@ -70,6 +70,8 @@ func TestAccPagerDutyExtension_Basic(t *testing.T) {
 						"pagerduty_extension.foo", "endpoint_url", url),
 					resource.TestCheckResourceAttr(
 						"pagerduty_extension.foo", "config", "{\"notify_types\":{\"acknowledge\":false,\"assignments\":false,\"resolve\":false},\"restrict\":\"any\"}"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_extension.foo", "html_url", ""),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -22,6 +22,10 @@ func resourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -296,6 +300,7 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("name", service.Name)
+	d.Set("html_url", service.HTMLURL)
 	d.Set("status", service.Status)
 	d.Set("created_at", service.CreatedAt)
 	d.Set("escalation_policy", service.EscalationPolicy.ID)

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -83,6 +83,8 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_service.foo", "html_url"),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -26,6 +26,10 @@ func resourcePagerDutyTeam() *schema.Resource {
 				Optional: true,
 				Default:  "Managed by Terraform",
 			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -56,7 +60,7 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(team.ID)
 
-	return nil
+	return resourcePagerDutyTeamRead(d, meta)
 
 }
 
@@ -72,6 +76,7 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", team.Name)
 	d.Set("description", team.Description)
+	d.Set("html_url", team.HTMLURL)
 
 	return nil
 }
@@ -87,7 +92,7 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	return nil
+	return resourcePagerDutyTeamRead(d, meta)
 }
 
 func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error {

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -69,6 +69,8 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 						"pagerduty_team.foo", "name", team),
 					resource.TestCheckResourceAttr(
 						"pagerduty_team.foo", "description", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_team.foo", "html_url"),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -145,6 +145,7 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", user.Name)
 	d.Set("email", user.Email)
 	d.Set("time_zone", user.TimeZone)
+	d.Set("html_url", user.HTMLURL)
 	d.Set("color", user.Color)
 	d.Set("role", user.Role)
 	d.Set("avatar_url", user.AvatarURL)
@@ -211,7 +212,7 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	return nil
+	return resourcePagerDutyUserRead(d, meta)
 }
 
 func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error {

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -79,6 +79,8 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 						"pagerduty_user.foo", "job_title", "foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "description", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_user.foo", "html_url"),
 				),
 			},
 			{

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 The following attributes are exported:
 
   * `id` - The ID of the extension.
-  * `html_url` - a URL at which the entity is uniquely displayed in the Web app
+  * `html_url` - URL at which the entity is uniquely displayed in the Web app
 
 ## Import
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -140,6 +140,7 @@ The following attributes are exported:
   * `last_incident_timestamp`- Last incident timestamp of the service
   * `created_at`- Creation timestamp of the service
   * `status`- The status of the service
+  * `html_url`- URL at which the entity is uniquely displayed in the Web app
 
 ## Import
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 The following attributes are exported:
 
   * `id` - The ID of the team.
+  * `html_url` - URL at which the entity is uniquely displayed in the Web app
 
 ## Import
 


### PR DESCRIPTION
This PR mainly adds supports for the `html_url` read-only attribute to the `pagerduty_service` resource.
This is useful to define the new `referer` attribute of extensions: https://github.com/terraform-providers/terraform-provider-pagerduty/issues/94#issuecomment-543627126

Support is also added to `pagerduty_team` resource.

Also it fixes this attribute for other resources:
- `pagerduty_extension` (note: all of the extensions I've checked return an empty string)
- `pagerduty_user`