### PR TITLE
resource/pagerduty/data_source_pagerduty_vendor: Fix ExactMatch test

### DIFF
--- a/pagerduty/data_source_pagerduty_vendor_test.go
+++ b/pagerduty/data_source_pagerduty_vendor_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourcePagerDutyVendor_ExactMatch(t *testing.T) {
 			{
 				Config: testAccDataSourcePagerDutyExactMatchConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "id", "PKG4M95"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", "PKAPG94"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "Sentry"),
 				),
 			},


### PR DESCRIPTION
PKG4M95 is the legacy vendor id.
This changes the test to use the non-legacy vendor id for Slack.

Fixes the following test failure:

```sh
------- Stdout: -------
=== RUN   TestAccDataSourcePagerDutyVendor_ExactMatch
--- FAIL: TestAccDataSourcePagerDutyVendor_ExactMatch (2.18s)
    testing.go:569: Step 0 error: Check failed: Check 1/2 error: data.pagerduty_vendor.foo: Attribute 'id' expected "PKG4M95", got "PKAPG94"
```