### PR TITLE
DOCS: Team membership role defaults to manager

### DIFF
--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
   * `user_id` - (Required) The ID of the user to add to the team.
   * `team_id` - (Required) The ID of the team in which the user will belong.
-  * `role`    - (Optional) The role of the user in the team. One of `observer`, `responder`, or `manager`. Defaults to `observer`.
+  * `role`    - (Optional) The role of the user in the team. One of `observer`, `responder`, or `manager`. Defaults to `manager`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This was added in https://github.com/terraform-providers/terraform-provider-pagerduty/pull/151, but the default team membership role is `manager`, update the docs to match.