### PR TITLE
Fixing Importing for Rulesets and Ruleset Rules. Adding Import Tests.

### DIFF
--- a/pagerduty/import_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/import_pagerduty_ruleset_rule_test.go
@@ -1,0 +1,38 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccPagerDutyRulesetRule_import(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	rule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyRulesetRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyRulesetRuleConfig(ruleset, teamName, rule),
+			},
+
+			{
+				ResourceName:      "pagerduty_ruleset_rule.foo",
+				ImportStateIdFunc: testAccCheckPagerDutyRulesetRuleID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyRulesetRuleID(s *terraform.State) (string, error) {
+	return fmt.Sprintf("%v.%v", s.RootModule().Resources["pagerduty_ruleset.foo"].Primary.ID, s.RootModule().Resources["pagerduty_ruleset_rule.foo"].Primary.ID), nil
+}

--- a/pagerduty/import_pagerduty_ruleset_test.go
+++ b/pagerduty/import_pagerduty_ruleset_test.go
@@ -1,0 +1,52 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccPagerDutyRuleset_import(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyRulesetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyRulesetConfig(ruleset, teamName),
+			},
+
+			{
+				ResourceName:      "pagerduty_ruleset.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyRulesetWithNoTeam_import(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyRulesetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyRulesetConfigNoTeam(ruleset),
+			},
+
+			{
+				ResourceName:      "pagerduty_ruleset.noteam",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/resource_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule_test.go
@@ -54,7 +54,7 @@ func TestAccPagerDutyRulesetRule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.operator", "contains"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.#", "2"),
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.0.path", "payload.summary"),
 					resource.TestCheckResourceAttr(
@@ -181,10 +181,6 @@ resource "pagerduty_ruleset_rule" "foo" {
 			parameter {
 				value = "disk space"
 				path = "payload.summary"
-			}
-			parameter {
-				value = "db"
-				path = "payload.source"
 			}
 		}
 	}

--- a/website/docs/r/ruleset.html.markdown
+++ b/website/docs/r/ruleset.html.markdown
@@ -36,9 +36,10 @@ The following arguments are supported:
 ## Attributes Reference
 
 The following attributes are exported:
+
 * `id` - The ID of the ruleset.
 * `routing_keys` - Routing keys routed to this ruleset.
-
+* `type` - Type of ruleset. Currently only sets to `global`.
 
 ## Import
 

--- a/website/docs/r/ruleset_rule.html.markdown
+++ b/website/docs/r/ruleset_rule.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Creates and manages a ruleset rule in PagerDuty.
 ---
 
-# pagerduty\_event_rule
+# pagerduty\_ruleset_rule
 
 An [event rule](https://support.pagerduty.com/docs/rulesets#section-create-event-rules) allows you to set actions that should be taken on events that meet your designated rule criteria.
 

--- a/website/docs/r/ruleset_rule.html.markdown
+++ b/website/docs/r/ruleset_rule.html.markdown
@@ -43,6 +43,9 @@ resource "pagerduty_ruleset_rule" "foo" {
 	    value = "disk space"
 		path = "payload.summary"
 	  }
+	}
+	subconditions {
+	  operator = "contains"
 	  parameter {
 	    value = "db"
 	    path = "payload.source"
@@ -122,8 +125,8 @@ The following attributes are exported:
 
 ## Import
 
-Ruleset rules can be imported using the `id`, e.g.
+Ruleset rules can be imported using using the related `ruleset` id and the `ruleset_rule` id separated by a dot, e.g.
 
 ```
-$ terraform import pagerduty_ruleset_rule.main 19acac92-027a-4ea0-b06c-bbf516519601
+$ terraform import pagerduty_ruleset_rule.main a19cdca1-3d5e-4b52-bfea-8c8de04da243.19acac92-027a-4ea0-b06c-bbf516519601
 ```

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -55,6 +55,12 @@
                 <li<%= sidebar_current("docs-pagerduty-resource-maintenance-window") %>>
                     <a href="/docs/providers/pagerduty/r/maintenance_window.html">pagerduty_maintenance_window</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-ruleset") %>>
+                    <a href="/docs/providers/pagerduty/r/ruleset.html">pagerduty_ruleset</a>
+                </li>
+                <li<%= sidebar_current("docs-pagerduty-resource-ruleset-rule") %>>
+                    <a href="/docs/providers/pagerduty/r/ruleset-rule.html">pagerduty_ruleset_rule</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-schedule") %>>
                     <a href="/docs/providers/pagerduty/r/schedule.html">pagerduty_schedule</a>
                 </li>

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -59,7 +59,7 @@
                     <a href="/docs/providers/pagerduty/r/ruleset.html">pagerduty_ruleset</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-ruleset-rule") %>>
-                    <a href="/docs/providers/pagerduty/r/ruleset-rule.html">pagerduty_ruleset_rule</a>
+                    <a href="/docs/providers/pagerduty/r/ruleset_rule.html">pagerduty_ruleset_rule</a>
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-schedule") %>>
                     <a href="/docs/providers/pagerduty/r/schedule.html">pagerduty_schedule</a>


### PR DESCRIPTION
Fleshing out the importing for `rulesets` and `ruleset_rules` and adding tests for imports for those resources. This addresses #197 

Test results

```
 TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule_Basic" ./pagerduty -v -timeout 120m 
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (6.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	7.098s

TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule_import" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (4.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	5.036s

TF_ACC=1 go test -run "TestAccPagerDutyRuleset_Basic" ./pagerduty -v -timeout 120m    
=== RUN   TestAccPagerDutyRuleset_Basic
--- PASS: TestAccPagerDutyRuleset_Basic (6.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	7.305s

 TF_ACC=1 go test -run "TestAccPagerDutyRuleset_import" ./pagerduty -v -timeout 120m    
=== RUN   TestAccPagerDutyRuleset_import
--- PASS: TestAccPagerDutyRuleset_import (5.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	5.525s

```