### PR TITLE
Fixing Ruleset_Rule Import of Catch All Rules

### DIFF
--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -623,8 +623,9 @@ func resourcePagerDutyRulesetRuleRead(d *schema.ResourceData, meta interface{}) 
 			}
 			return resource.NonRetryableError(err)
 		} else if rule != nil {
-			d.Set("conditions", flattenConditions(rule.Conditions))
-
+			if rule.Conditions != nil {
+				d.Set("conditions", flattenConditions(rule.Conditions))
+			}
 			if rule.Actions != nil {
 				d.Set("actions", flattenActions(rule.Actions))
 			}


### PR DESCRIPTION
Addresses issue #197 

```
TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (7.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	8.230s
terraform-provider-pagerduty $ TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule_import" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (5.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	5.572s
```