### PR TITLE
resource_pagerduty_service_integration: Fix panic

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -28,6 +28,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 			"service": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"type": {
 				Type:          schema.TypeString,
@@ -142,6 +143,8 @@ func resourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interf
 				log.Printf("[WARN] Returning retryable error")
 				return resource.RetryableError(errResp)
 			}
+
+			return nil
 		}
 
 		d.Set("name", serviceIntegration.Name)


### PR DESCRIPTION
Fixes #204 

If the service integration cannot be found we must return early, this is
to prevent running into a panic when trying to dereference further down
when setting the state.

We also mark the "service" attribute with ForceNew since we don't have a
way of migrating service integrations to another service. This means
that service integrations will be destroyed and re-created. This fixes
the current behavior where Terraform would just return an error, forcing
the user to run Terraform again so that the new service integration can
be created. This fixes it all in one go by destroying the previous
service integration from the old service and adding it to the new
service without having to run it two times. Note: This only happens if
the "service" attribute changes.