### PR TITLE
resource_pagerduty_service: Fix panic

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -306,6 +306,8 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 				log.Printf("[WARN] Returning retryable error")
 				return resource.RetryableError(errResp)
 			}
+
+			return nil
 		}
 
 		d.Set("name", service.Name)


### PR DESCRIPTION
Relates to #214.

If the service cannot be found we must return early, this is
to prevent running into a panic when trying to dereference further down
when setting the state.

Fixes the following panic found in the tests:

```bash
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourcePagerDutyService_Basic

------- Stderr: -------
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf9d8e3]

goroutine 203 [running]:
github.com/terraform-providers/terraform-provider-pagerduty/pagerduty.resourcePagerDutyServiceRead.func1(0xc0005627d0)
	/opt/teamcity-agent/work/9161763f6c1b3702/src/github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/resource_pagerduty_service.go:311 +0xf3
github.com/hashicorp/terraform-plugin-sdk/helper/resource.Retry.func1(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/9161763f6c1b3702/src/github.com/terraform-providers/terraform-provider-pagerduty/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/wait.go:22 +0x4e
github.com/hashicorp/terraform-plugin-sdk/helper/resource.(*StateChangeConf).WaitForState.func1(0xc000576600, 0xc00011a700, 0xc00044f640, 0xc00064c120, 0xc000422bc8, 0xc000422bc0)
	/opt/teamcity-agent/work/9161763f6c1b3702/src/github.com/terraform-providers/terraform-provider-pagerduty/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go:103 +0x29e
created by github.com/hashicorp/terraform-plugin-sdk/helper/resource.(*StateChangeConf).WaitForState
	/opt/teamcity-agent/work/9161763f6c1b3702/src/github.com/terraform-providers/terraform-provider-pagerduty/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go:80 +0x1b9
```