### PR TITLE
testing: update sweepers

### DIFF
--- a/pagerduty/resource_pagerduty_event_rule_test.go
+++ b/pagerduty/resource_pagerduty_event_rule_test.go
@@ -3,7 +3,6 @@ package pagerduty
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -39,11 +38,9 @@ func testSweepEventRule(region string) error {
 	}
 
 	for _, rule := range resp.EventRules {
-		if strings.HasPrefix(rule.ID, "test") || strings.HasPrefix(rule.ID, "tf-") {
-			log.Printf("Destroying event rule %s", rule.ID)
-			if _, err := client.EventRules.Delete(rule.ID); err != nil {
-				return err
-			}
+		log.Printf("Destroying event rule %s", rule.ID)
+		if _, err := client.EventRules.Delete(rule.ID); err != nil {
+			return err
 		}
 	}
 

--- a/pagerduty/resource_pagerduty_event_rule_test.go
+++ b/pagerduty/resource_pagerduty_event_rule_test.go
@@ -40,7 +40,7 @@ func testSweepEventRule(region string) error {
 	for _, rule := range resp.EventRules {
 		log.Printf("Destroying event rule %s", rule.ID)
 		if _, err := client.EventRules.Delete(rule.ID); err != nil {
-			return err
+			log.Printf("[ERROR] Failed to delete event rule: %s", err)
 		}
 	}
 

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -41,7 +41,7 @@ func testSweepUser(region string) error {
 	}
 
 	for _, user := range resp.Users {
-		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf-") {
+		if strings.HasPrefix(user.Name, "test") || strings.HasPrefix(user.Name, "tf") {
 			log.Printf("Destroying user %s (%s)", user.Name, user.ID)
 			if _, err := client.Users.Delete(user.ID); err != nil {
 				return err


### PR DESCRIPTION
Clean up all test event rules for the pre/post sweeper.

We also had a couple of test users called tf<uuid>, this matches those
too.