### PR TITLE
extension: set default config to {}

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -54,6 +54,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 			"config": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Default:          "{}",
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},


### PR DESCRIPTION
When creating an extension with no configuration, the PagerDuty API still responds with `{config: {}}`. This results in a perpetual diff if `config` is unset:

```
- config            = jsonencode({}) -> null
```

By setting the default to `{}`, Terraform will no long observe a diff. This does mean that `{}` will be transmitted to the server, but avoids writing a diff suppression func that ignores `{}` -> `nil`. If you'd rather I do that instead, happy to do so.