### PR TITLE
Adding Ruleset Data Source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-pagerduty
 require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7
+	github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20200415004831-bc2b3224a572 h1:UPbUDXwtlg
 github.com/heimweh/go-pagerduty v0.0.0-20200415004831-bc2b3224a572/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7 h1:8groiuI/kigz8jYT46EKNqDYVcEfSDnhv5p+VgZfPGU=
 github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24 h1:ga84s0DaOnrYN7IL7jMug6ins5QpiMuNpXFxCKqFAvg=
+github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/data_source_pagerduty_ruleset.go
+++ b/pagerduty/data_source_pagerduty_ruleset.go
@@ -1,0 +1,53 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyRuleset() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyRulesetRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyRulesetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty ruleset")
+
+	searchName := d.Get("name").(string)
+
+	resp, _, err := client.Rulesets.List()
+	if err != nil {
+		return err
+	}
+
+	var found *pagerduty.Ruleset
+
+	for _, ruleset := range resp.Rulesets {
+		if ruleset.Name == searchName {
+			found = ruleset
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any ruleset with the name: %s", searchName)
+	}
+
+	d.SetId(found.ID)
+	d.Set("name", found.Name)
+
+	return nil
+}

--- a/pagerduty/data_source_pagerduty_ruleset_test.go
+++ b/pagerduty/data_source_pagerduty_ruleset_test.go
@@ -1,0 +1,64 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourcePagerDutyRuleset_Basic(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyRulesetConfig(ruleset),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyRuleset("pagerduty_ruleset.test", "data.pagerduty_ruleset.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyRuleset(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a ruleset ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name"}
+
+		for _, att := range testAtts {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("Expected the ruleset %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyRulesetConfig(ruleset string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_ruleset" "test" {
+  name                    = "%s"
+}
+
+data "pagerduty_ruleset" "by_name" {
+  name = pagerduty_ruleset.test.name
+}
+`, ruleset)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -75,7 +75,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func isErrCode(err error, code int) bool {
-	if e, ok := err.(*pagerduty.Error); ok && e.ErrorResponse.StatusCode == code {
+	if e, ok := err.(*pagerduty.Error); ok && e.ErrorResponse.Response.StatusCode == code {
 		return true
 	}
 

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -37,6 +37,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_service":           dataSourcePagerDutyService(),
 			"pagerduty_business_service":  dataSourcePagerDutyBusinessService(),
 			"pagerduty_priority":          dataSourcePagerDutyPriority(),
+			"pagerduty_ruleset":           dataSourcePagerDutyRuleset(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/error.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/error.go
@@ -28,5 +28,5 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s API call to %s failed %v. Code: %d, Errors: %v, Message: %s", e.ErrorResponse.Request.Method, e.ErrorResponse.Request.URL.String(), e.ErrorResponse.Response.Status, e.Code, e.Errors, e.Message)
+	return fmt.Sprintf("%s API call to %s failed %v. Code: %d, Errors: %v, Message: %s", e.ErrorResponse.Response.Request.Method, e.ErrorResponse.Response.Request.URL.String(), e.ErrorResponse.Response.Status, e.Code, e.Errors, e.Message)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -54,7 +55,8 @@ type Client struct {
 
 // Response is a wrapper around http.Response
 type Response struct {
-	*http.Response
+	Response  *http.Response
+	BodyBytes []byte
 }
 
 // NewClient returns a new PagerDuty API client.
@@ -156,21 +158,69 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	response := &Response{
+		Response:  resp,
+		BodyBytes: bodyBytes,
+	}
 
-	response := &Response{resp}
-
-	if err := checkResponse(response); err != nil {
+	if err := c.checkResponse(response); err != nil {
 		return response, err
 	}
 
 	if v != nil {
-		if err := decodeJSON(response, v); err != nil {
+		if err := c.DecodeJSON(response, v); err != nil {
 			return response, err
 		}
 	}
 
 	return response, nil
+}
+
+// ListResp represents a list response from the PagerDuty API
+type ListResp struct {
+	Offset int  `json:"offset,omitempty"`
+	Limit  int  `json:"limit,omitempty"`
+	More   bool `json:"more,omitempty"`
+	Total  int  `json:"total,omitempty"`
+}
+
+// responseHandler is capable of parsing a response. At a minimum it must
+// extract the page information for the current page. It can also execute
+// additional necessary handling; for example, if a closure, it has access
+// to the scope in which it was defined, and can be used to append data to
+// a specific slice. The responseHandler is responsible for closing the response.
+type responseHandler func(response *Response) (ListResp, *Response, error)
+
+func (c *Client) newRequestPagedGetDo(basePath string, handler responseHandler) error {
+	// Indicates whether there are still additional pages associated with request.
+	var stillMore bool
+
+	// Offset to set for the next page request.
+	var nextOffset int
+
+	// While there are more pages, keep adjusting the offset to get all results.
+	for stillMore, nextOffset = true, 0; stillMore; {
+		response, err := c.newRequestDo("GET", fmt.Sprintf("%s?offset=%d", basePath, nextOffset), nil, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		// Call handler to extract page information and execute additional necessary handling.
+		pageInfo, _, err := handler(response)
+		if err != nil {
+			return err
+		}
+
+		// Bump the offset as necessary and set whether more results exist.
+		nextOffset = pageInfo.Offset + pageInfo.Limit
+		stillMore = pageInfo.More
+	}
+
+	return nil
 }
 
 // ValidateAuth validates a token against the PagerDuty API
@@ -179,23 +229,24 @@ func (c *Client) ValidateAuth() error {
 	return err
 }
 
-func decodeJSON(res *Response, v interface{}) error {
-	return json.NewDecoder(res.Body).Decode(v)
+// DecodeJSON decodes json body to given interface
+func (c *Client) DecodeJSON(res *Response, v interface{}) error {
+	return json.Unmarshal(res.BodyBytes, v)
 }
 
-func checkResponse(res *Response) error {
-	if res.StatusCode >= 200 && res.StatusCode <= 299 {
+func (c *Client) checkResponse(res *Response) error {
+	if res.Response.StatusCode >= 200 && res.Response.StatusCode <= 299 {
 		return nil
 	}
 
-	return decodeErrorResponse(res)
+	return c.decodeErrorResponse(res)
 }
 
-func decodeErrorResponse(res *Response) error {
+func (c *Client) decodeErrorResponse(res *Response) error {
 	// Try to decode error response or fallback with standard error
 	v := &errorResponse{Error: &Error{ErrorResponse: res}}
-	if err := decodeJSON(res, v); err != nil {
-		return fmt.Errorf("%s API call to %s failed: %v", res.Request.Method, res.Request.URL.String(), res.Status)
+	if err := c.DecodeJSON(res, v); err != nil {
+		return fmt.Errorf("%s API call to %s failed: %v", res.Response.Request.Method, res.Response.Request.URL.String(), res.Response.Status)
 	}
 
 	return v.Error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7
+# github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath

--- a/website/docs/d/priority.html.markdown
+++ b/website/docs/d/priority.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_priority
 
-Use this data source to get information about a specific [priority][1] that you can use for other PagerDuty resources.
+Use this data source to get information about a specific [priority][1] that you can use for other PagerDuty resources. A priority is a label representing the importance and impact of an incident. This feature is only available on Standard and Enterprise plans.
 
 ## Example Usage
 

--- a/website/docs/d/ruleset.html.markdown
+++ b/website/docs/d/ruleset.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_ruleset"
+sidebar_current: "docs-pagerduty-datasource-ruleset"
+description: |-
+  Get information about a ruleset that you have created.
+---
+
+# pagerduty\_ruleset
+
+Use this data source to get information about a specific [ruleset][1] that you can use for managing and grouping [event rules][2].
+
+## Example Usage
+
+```hcl
+data "pagerduty_ruleset" "example" {
+  name = "My Ruleset"
+}
+
+resource "pagerduty_ruleset_rule" "foo" {
+  ruleset = data.pagerduty_ruleset.example.id
+  position = 0
+  disabled = "false"
+  conditions {
+    operator = "and"
+	subconditions {
+	  operator = "contains"
+	  parameter {
+	    value = "disk space"
+		path = "payload.summary"
+	  }
+	}
+	subconditions {
+	  operator = "contains"
+	  parameter {
+	    value = "db"
+	    path = "payload.source"
+	  }
+	}
+  }
+  actions {
+    route {
+	  value = "P5DTL0K"
+	}
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the ruleset to find in the PagerDuty API.
+
+## Attributes Reference
+* `id` - The ID of the found ruleset.
+* `name` - The name of the found ruleset.
+
+[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1rulesets/get
+[2]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1rulesets~1%7Bid%7D~1rules/get

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -36,7 +36,9 @@ The following arguments are supported:
 
   * `user_id` - (Required) The ID of the user to add to the team.
   * `team_id` - (Required) The ID of the team in which the user will belong.
-  * `role`    - (Optional) The role of the user in the team. One of `observer`, `responder`, or `manager`. Defaults to `manager`.
+  * `role`    - (Optional) The role of the user in the team. One of `observer`, `responder`, or `manager`. Defaults to `manager`. These roles match up to user roles in the following ways:
+    * User role of `user` is a Team role of `manager`
+    * User role of `limited_user` is a Team role of `responder`
 
 ## Attributes Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
   * `name` - (Required) The name of the user.
   * `email` - (Required) The user's email address.
   * `color` - (Optional) The schedule color for the user. Valid options are purple, red, green, blue, teal, orange, brown, turquoise, dark-slate-blue, cayenne, orange-red, dark-orchid, dark-slate-grey, lime, dark-magenta, lime-green, midnight-blue, deep-pink, dark-green, dark-orange, dark-cyan, darkolive-green, dark-slate-gray, grey20, firebrick, maroon, crimson, dark-red, dark-goldenrod, chocolate, medium-violet-red, sea-green, olivedrab, forest-green, dark-olive-green, blue-violet, royal-blue, indigo, slate-blue, saddle-brown, or steel-blue.
-  * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `observer`, `owner`, `read_only_user` or `user`
+  * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `observer`, `owner`, `read_only_user`, `restricted_user`, or `user`
   * `job_title` - (Optional) The user's title.
   * `teams` - (Optional, **DEPRECATED**) A list of teams the user should belong to. Please use `pagerduty_team_membership` instead.
   * `description` - (Optional) A human-friendly description of the user.

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -19,6 +19,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-extension-schema") %>>
                     <a href="/docs/providers/pagerduty/d/extension_schema.html">pagerduty_extension_schema</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-priority") %>>
+                    <a href="/docs/providers/pagerduty/d/priority.html">pagerduty_priority</a>
+                </li>                
                 <li<%= sidebar_current("docs-pagerduty-datasource-schedule") %>>
                     <a href="/docs/providers/pagerduty/d/schedule.html">pagerduty_schedule</a>
                 </li>

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -21,6 +21,9 @@
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-priority") %>>
                     <a href="/docs/providers/pagerduty/d/priority.html">pagerduty_priority</a>
+                </li>                  
+                <li<%= sidebar_current("docs-pagerduty-datasource-ruleset") %>>
+                    <a href="/docs/providers/pagerduty/d/ruleset.html">pagerduty_ruleset</a>
                 </li>                
                 <li<%= sidebar_current("docs-pagerduty-datasource-schedule") %>>
                     <a href="/docs/providers/pagerduty/d/schedule.html">pagerduty_schedule</a>


### PR DESCRIPTION
This adds the Ruleset Data Source along with Docs and tests (results shown below):

```
TF_ACC=1 go test -run "TestAccDataSourcePagerDutyRuleset_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccDataSourcePagerDutyRuleset_Basic
--- PASS: TestAccDataSourcePagerDutyRuleset_Basic (3.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	4.097s
```