### PR TITLE
Updating service_dependency to support technical service dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-pagerduty
 require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24
+	github.com/heimweh/go-pagerduty v0.0.0-20200603015639-6677e9a50383
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7 h1:8groiuI/ki
 github.com/heimweh/go-pagerduty v0.0.0-20200429000711-fdd3a48907e7/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24 h1:ga84s0DaOnrYN7IL7jMug6ins5QpiMuNpXFxCKqFAvg=
 github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20200603015639-6677e9a50383 h1:IMMksFroOt5lul7trOUQZjP4nlCIE5XiRrJqCxZ07Jo=
+github.com/heimweh/go-pagerduty v0.0.0-20200603015639-6677e9a50383/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/import_pagerduty_service_dependency_test.go
+++ b/pagerduty/import_pagerduty_service_dependency_test.go
@@ -19,10 +19,10 @@ func TestAccPagerDutyServiceDependency_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPagerDutyServiceDependencyDestroy,
+		CheckDestroy: testAccCheckPagerDutyBusinessServiceDependencyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyServiceDependencyConfig(service, businessService, username, email, escalationPolicy),
+				Config: testAccCheckPagerDutyBusinessServiceDependencyConfig(service, businessService, username, email, escalationPolicy),
 			},
 
 			{

--- a/pagerduty/resource_pagerduty_service_dependency_test.go
+++ b/pagerduty/resource_pagerduty_service_dependency_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
-func TestAccPagerDutyServiceDependency_Basic(t *testing.T) {
+// Testing Business Service Dependencies
+func TestAccPagerDutyBusinessServiceDependency_Basic(t *testing.T) {
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	businessService := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -20,12 +21,12 @@ func TestAccPagerDutyServiceDependency_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPagerDutyServiceDependencyDestroy,
+		CheckDestroy: testAccCheckPagerDutyBusinessServiceDependencyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyServiceDependencyConfig(service, businessService, username, email, escalationPolicy),
+				Config: testAccCheckPagerDutyBusinessServiceDependencyConfig(service, businessService, username, email, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyServiceDependencyExists("pagerduty_service_dependency.foo"),
+					testAccCheckPagerDutyBusinessServiceDependencyExists("pagerduty_service_dependency.foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_dependency.foo", "dependency.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -37,7 +38,7 @@ func TestAccPagerDutyServiceDependency_Basic(t *testing.T) {
 		},
 	})
 }
-func testAccCheckPagerDutyServiceDependencyExists(n string) resource.TestCheckFunc {
+func testAccCheckPagerDutyBusinessServiceDependencyExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -47,12 +48,11 @@ func testAccCheckPagerDutyServiceDependencyExists(n string) resource.TestCheckFu
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Service Relationship ID is set")
 		}
-
 		businessService, _ := s.RootModule().Resources["pagerduty_business_service.foo"]
 
 		client := testAccProvider.Meta().(*pagerduty.Client)
 
-		depResp, _, err := client.ServiceDependencies.GetBusinessServiceDependencies(businessService.Primary.ID)
+		depResp, _, err := client.ServiceDependencies.GetServiceDependenciesForType(businessService.Primary.ID, "business_service")
 		if err != nil {
 			return fmt.Errorf("Business Service not found: %v", err)
 		}
@@ -73,7 +73,7 @@ func testAccCheckPagerDutyServiceDependencyExists(n string) resource.TestCheckFu
 	}
 }
 
-func testAccCheckPagerDutyServiceDependencyDestroy(s *terraform.State) error {
+func testAccCheckPagerDutyBusinessServiceDependencyDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*pagerduty.Client)
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "pagerduty_service_dependency" {
@@ -82,7 +82,7 @@ func testAccCheckPagerDutyServiceDependencyDestroy(s *terraform.State) error {
 		businessService, _ := s.RootModule().Resources["pagerduty_business_service.foo"]
 
 		// get business service
-		dependencies, _, err := client.ServiceDependencies.GetBusinessServiceDependencies(businessService.Primary.ID)
+		dependencies, _, err := client.ServiceDependencies.GetServiceDependenciesForType(businessService.Primary.ID, "business_service")
 		if err != nil {
 			// if the business service doesn't exist, that's okay
 			return nil
@@ -90,14 +90,14 @@ func testAccCheckPagerDutyServiceDependencyDestroy(s *terraform.State) error {
 		// get business service dependencies
 		for _, rel := range dependencies.Relationships {
 			if rel.ID == r.Primary.ID {
-				return fmt.Errorf("Business service relationship still exists")
+				return fmt.Errorf("supporting service relationship still exists")
 			}
 		}
 
 	}
 	return nil
 }
-func testAccCheckPagerDutyServiceDependencyConfig(service, businessService, username, email, escalationPolicy string) string {
+func testAccCheckPagerDutyBusinessServiceDependencyConfig(service, businessService, username, email, escalationPolicy string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_business_service" "foo" {
 	name = "%s"
@@ -145,4 +145,147 @@ resource "pagerduty_service_dependency" "foo" {
 	}
 }
 `, businessService, username, email, escalationPolicy, service)
+}
+
+// Testing Technical Service Dependencies
+func TestAccPagerDutyTechnicalServiceDependency_Basic(t *testing.T) {
+	dependentService := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	supportingService := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTechnicalServiceDependencyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTechnicalServiceDependencyConfig(dependentService, supportingService, username, email, escalationPolicy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTechnicalServiceDependencyExists("pagerduty_service_dependency.bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_dependency.bar", "dependency.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_dependency.bar", "dependency.0.supporting_service.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_dependency.bar", "dependency.0.dependent_service.#", "1"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckPagerDutyTechnicalServiceDependencyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Service Relationship ID is set")
+		}
+		supportService, _ := s.RootModule().Resources["pagerduty_service.supportBar"]
+
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		depResp, _, err := client.ServiceDependencies.GetServiceDependenciesForType(supportService.Primary.ID, "service")
+		if err != nil {
+			return fmt.Errorf("Technical Service not found: %v", err)
+		}
+		var foundRel *pagerduty.ServiceDependency
+
+		// loop serviceRelationships until relationship.IDs match
+		for _, rel := range depResp.Relationships {
+			if rel.ID == rs.Primary.ID {
+				foundRel = rel
+				break
+			}
+		}
+		if foundRel == nil {
+			return fmt.Errorf("Service Dependency not found: %v", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyTechnicalServiceDependencyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_service_dependency" {
+			continue
+		}
+		supportService, _ := s.RootModule().Resources["pagerduty_service.supportBar"]
+
+		// get service dependencies
+		dependencies, _, err := client.ServiceDependencies.GetServiceDependenciesForType(supportService.Primary.ID, "service")
+		if err != nil {
+			// if the dependency doesn't exist, that's okay
+			return nil
+		}
+		// find desired dependency
+		for _, rel := range dependencies.Relationships {
+			if rel.ID == r.Primary.ID {
+				return fmt.Errorf("supporting service relationship still exists")
+			}
+		}
+
+	}
+	return nil
+}
+func testAccCheckPagerDutyTechnicalServiceDependencyConfig(dependentService, supportingService, username, email, escalationPolicy string) string {
+	return fmt.Sprintf(`
+
+
+resource "pagerduty_user" "bar" {
+	name        = "%s"
+	email       = "%s"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "bar" {
+	name        = "%s"
+	description = "bar-desc"
+	num_loops   = 2
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = pagerduty_user.bar.id
+		}
+	}
+}
+resource "pagerduty_service" "supportBar" {
+	name = "%s"
+	description             = "supportBarDesc"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service" "dependBar" {
+	name = "%s"
+	description             = "dependBarDesc"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service_dependency" "bar" {
+	dependency {
+		dependent_service {
+			id = pagerduty_service.dependBar.id
+			type = "service"
+		}
+		supporting_service {
+			id = pagerduty_service.supportBar.id
+			type = "service"
+		}
+	}
+}
+`, username, email, escalationPolicy, supportingService, dependentService)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/business_service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/business_service.go
@@ -8,14 +8,22 @@ type BusinessServiceService service
 
 // BusinessService represents a business service.
 type BusinessService struct {
-	ID             string `json:"id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	Type           string `json:"type,omitempty"`
-	Summary        string `json:"summary,omitempty"`
-	Self           string `json:"self,omitempty"`
-	PointOfContact string `json:"point_of_contact,omitempty"`
-	HTMLUrl        string `json:"html_url,omitempty"`
-	Description    string `json:"description,omitempty"`
+	ID             string               `json:"id,omitempty"`
+	Name           string               `json:"name,omitempty"`
+	Type           string               `json:"type,omitempty"`
+	Summary        string               `json:"summary,omitempty"`
+	Self           string               `json:"self,omitempty"`
+	PointOfContact string               `json:"point_of_contact,omitempty"`
+	HTMLUrl        string               `json:"html_url,omitempty"`
+	Description    string               `json:"description,omitempty"`
+	Team           *BusinessServiceTeam `json:"team,omitempty"`
+}
+
+// BusinessServiceTeam represents a team object in a business service
+type BusinessServiceTeam struct {
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+	Self string `json:"self,omitempty"`
 }
 
 // BusinessServicePayload represents payload with a business service object

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service_dependency.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service_dependency.go
@@ -52,9 +52,33 @@ func (s *ServiceDependencyService) DisassociateServiceDependencies(dependencies 
 	return v, resp, nil
 }
 
-// GetBusinessServiceDependencies gets all immediate dependencies of a business service.
-func (s *ServiceDependencyService) GetBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *Response, error) {
+// GetServiceDependenciesForType gets all immediate dependencies of a dependent service.
+func (s *ServiceDependencyService) GetServiceDependenciesForType(serviceID, serviceType string) (*ListServiceDependencies, *Response, error) {
+	if serviceType == "business_service" || serviceType == "business_service_reference" {
+		return s.getBusinessServiceDependencies(serviceID)
+	} else if serviceType == "service" || serviceType == "technical_service_reference" {
+		return s.getTechnicalServiceDependencies(serviceID)
+	}
+	// return a not found error
+	return nil, nil, fmt.Errorf("dependent Service type of %s not found", serviceType)
+}
+
+// getBusinessServiceDependencies gets all immediate dependencies of a business service.
+func (s *ServiceDependencyService) getBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *Response, error) {
 	u := fmt.Sprintf("/service_dependencies/business_services/%s", businessServiceID)
+	v := new(ListServiceDependencies)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// getTechnicalServiceDependencies gets all immediate dependencies of a technical service.
+func (s *ServiceDependencyService) getTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, *Response, error) {
+	u := fmt.Sprintf("/service_dependencies/technical_services/%s", serviceID)
 	v := new(ListServiceDependencies)
 
 	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20200528011640-24a6d8472a24
+# github.com/heimweh/go-pagerduty v0.0.0-20200603015639-6677e9a50383
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_service\_dependency
 
-A [service dependency](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1service_dependencies~1associate/post) is a relationship between a business service and technical and business services that this service uses, or that are used by this service, and are critical for successful operation.
+A [service dependency](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1service_dependencies~1associate/post) is a relationship between two services that this service uses, or that are used by this service, and are critical for successful operation.
 
 
 ## Example Usage
@@ -57,8 +57,8 @@ The following attributes are exported:
 
 ## Import
 
-Service dependencies can be imported using the related business service id and the dependency id separated by a dot, e.g.
+Service dependencies can be imported using the related supporting service id, supporting service type (`business_service` or `service`) and the dependency id separated by a dot, e.g.
 
 ```
-$ terraform import pagerduty_service_dependency.main P4B2Z7G.D5RTHKRNGU4PYE90PJ
+$ terraform import pagerduty_service_dependency.main P4B2Z7G.business_service.D5RTHKRNGU4PYE90PJ
 ```

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -55,6 +55,8 @@ The following attributes are exported:
 
   * `id` - The ID of the service dependency.
 
+***NOTE: Due to the API supporting this resource, it does not support updating. To make changes to a `service_dependency` you'll need to destroy and then create a new one.***
+
 ## Import
 
 Service dependencies can be imported using the related supporting service id, supporting service type (`business_service` or `service`) and the dependency id separated by a dot, e.g.


### PR DESCRIPTION
Added support for technical service dependencies as well as tests for that feature. Also updated the docs.  This addresses #226

Test results
```
TF_ACC=1 go test -run "TestAccPagerDutyBusinessServiceDependency_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyBusinessServiceDependency_Basic
--- PASS: TestAccPagerDutyBusinessServiceDependency_Basic (12.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	12.994s

TF_ACC=1 go test -run "TestAccPagerDutyTechnicalServiceDependency_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyTechnicalServiceDependency_Basic
--- PASS: TestAccPagerDutyTechnicalServiceDependency_Basic (11.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	12.172s

```

