### PR TITLE
Add example of referencing the Default Global Ruleset

### DIFF
--- a/website/docs/d/ruleset.html.markdown
+++ b/website/docs/d/ruleset.html.markdown
@@ -48,10 +48,10 @@ resource "pagerduty_ruleset_rule" "foo" {
 
 ### Default Global Ruleset
 
-```
+```hcl
 data "pagerduty_ruleset" "default_global" {
   name = "Default Global"
-}w
+}
 ```
 
 ## Argument Reference

--- a/website/docs/d/ruleset.html.markdown
+++ b/website/docs/d/ruleset.html.markdown
@@ -46,6 +46,14 @@ resource "pagerduty_ruleset_rule" "foo" {
 }
 ```
 
+### Default Global Ruleset
+
+```
+data "pagerduty_ruleset" "default_global" {
+  name = "Default Global"
+}w
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
It wasn't exactly clear how to reference the default global ruleset, but I realized I could query the API to find the name of the ruleset:

```
curl -H "Authorization: Token token=$PAGERDUTY_TOKEN" https://api.pagerduty.com/rulesets
```

This showed me the name, which is "Default Global." In hindsight, this now makes sense looking at the PagerDuty dashboard, but it wasn't clear before I looked at the API response. I thought this would help others like me!