### PR TITLE
Added team to pagerduty_business_service resource

### DIFF
--- a/pagerduty/resource_pagerduty_business_service_test.go
+++ b/pagerduty/resource_pagerduty_business_service_test.go
@@ -91,6 +91,36 @@ func TestAccPagerDutyBusinessService_Basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyBusinessService_WithTeam(t *testing.T) {
+	businessService := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	description := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	pointOfContact := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyBusinessServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyBusinessServiceWithTeamConfig(businessService, teamName, description, pointOfContact),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyBusinessServiceExists("pagerduty_business_service.bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_business_service.bar", "name", businessService),
+					resource.TestCheckResourceAttr(
+						"pagerduty_business_service.bar", "description", description),
+					resource.TestCheckResourceAttr(
+						"pagerduty_business_service.bar", "point_of_contact", pointOfContact),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_business_service.bar", "self"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyBusinessServiceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -149,4 +179,20 @@ resource "pagerduty_business_service" "foo" {
 	point_of_contact = "%s"
 }
 `, name, description, poc)
+}
+
+func testAccCheckPagerDutyBusinessServiceWithTeamConfig(businessServiceName, teamName, description, poc string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_team" "bar" {
+	name = "%s"
+}
+	
+resource "pagerduty_business_service" "bar" {
+	name = "%s"
+	description = "%s"
+	point_of_contact = "%s"
+	team = pagerduty_team.bar.id
+}
+`, teamName, businessServiceName, description, poc)
 }

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -600,7 +600,7 @@ func resourcePagerDutyRulesetRuleCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[INFO] Creating PagerDuty ruleset rule for ruleset: %s", rule.Ruleset.ID)
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Rulesets.CreateRule(rule.Ruleset.ID, rule); err != nil {
 			return resource.RetryableError(err)
 		} else if rule != nil {
@@ -621,7 +621,7 @@ func resourcePagerDutyRulesetRuleRead(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Reading PagerDuty ruleset rule: %s", d.Id())
 	rulesetID := d.Get("ruleset").(string)
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Rulesets.GetRule(rulesetID, d.Id()); err != nil {
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)

--- a/website/docs/r/business_service.html.markdown
+++ b/website/docs/r/business_service.html.markdown
@@ -18,6 +18,7 @@ resource "pagerduty_business_service" "example" {
   name             = "My Web App"
   description      = "A very descriptive description of this business service"
   point_of_contact = "PagerDuty Admin"
+  team = "P37RSRS"
 }
 ```
 
@@ -30,7 +31,8 @@ The following arguments are supported:
     If not set, a placeholder of "Managed by Terraform" will be set.
   * `point_of_contact` - (Optional) The owner of the business service. 
   * `type` - (Optional) Default value is `business_service`. Can also be set as `business_service_reference`.
-
+  * `team` - (Optional) ID of the team that owns the business service.
+  
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/business_service.html.markdown
+++ b/website/docs/r/business_service.html.markdown
@@ -18,7 +18,7 @@ resource "pagerduty_business_service" "example" {
   name             = "My Web App"
   description      = "A very descriptive description of this business service"
   point_of_contact = "PagerDuty Admin"
-  team = "P37RSRS"
+  team             = "P37RSRS"
 }
 ```
 


### PR DESCRIPTION
Added the `team` field to the `pagerduty_business_service` resource.

```
TF_ACC=1 go test -run "TestAccPagerDutyBusinessService*" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyBusinessService_import
--- PASS: TestAccPagerDutyBusinessService_import (2.01s)
=== RUN   TestAccPagerDutyBusinessService_Basic
--- PASS: TestAccPagerDutyBusinessService_Basic (2.72s)
=== RUN   TestAccPagerDutyBusinessService_WithTeam
--- PASS: TestAccPagerDutyBusinessService_WithTeam (3.00s)
=== RUN   TestAccPagerDutyBusinessServiceDependency_Basic
--- PASS: TestAccPagerDutyBusinessServiceDependency_Basic (9.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	17.535s
```


Also increased retry time on Ruleset Rule Creation in attempts to help avoid collisions on the PagerDuty API. 
```
TF_ACC=1 go test -run "TestAccPagerDutyRuleset*" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (5.07s)
=== RUN   TestAccPagerDutyRuleset_import
--- PASS: TestAccPagerDutyRuleset_import (4.59s)
=== RUN   TestAccPagerDutyRulesetWithNoTeam_import
--- PASS: TestAccPagerDutyRulesetWithNoTeam_import (2.01s)
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (5.59s)
=== RUN   TestAccPagerDutyRuleset_Basic
--- PASS: TestAccPagerDutyRuleset_Basic (7.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	25.397s
```