### PR TITLE
Service integration retry on create

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -115,7 +115,7 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 
 	service := d.Get("service").(string)
 
-	retryErr := resource.Retry(15*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
 			if isErrCode(err, 400) {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -115,12 +115,23 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 
 	service := d.Get("service").(string)
 
-	serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration)
-	if err != nil {
-		return err
-	}
+	retryErr := resource.Retry(15*time.Second, func() *resource.RetryError {
+		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
+			if isErrCode(err, 400) {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(err)
+			}
 
-	d.SetId(serviceIntegration.ID)
+			return resource.NonRetryableError(err)
+		} else if serviceIntegration != nil {
+			d.SetId(serviceIntegration.ID)
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return retryErr
+	}
 
 	return resourcePagerDutyServiceIntegrationRead(d, meta)
 }


### PR DESCRIPTION
This pull request provides a workaround for a customer-reported bug whereby, when trying to create 15+ Custom Event Transformer integrations, some fail with a 400 status code.  To resolve this issue, I added retry logic (on 400s) to the service_integration resource's create function.  I tested with double the volume at which the customer reported the issue, and after finding a functioning timeout duration (45s), I padded the timeout slightly (to 1m).  